### PR TITLE
remove redundant non-AWS-specific BSL/VSL documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ Copy one of the returned IDs `<ID>` and use it with the `aws` CLI tool to search
 [4]: https://velero.io/docs/master/install-overview/#install-the-cli
 [5]: #Migrating-PVs-across-clusters
 [6]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
-[7]: backupstoragelocation.md#aws
-[8]: volumesnapshotlocation.md#aws
+[7]: backupstoragelocation.md
+[8]: volumesnapshotlocation.md
 [9]: https://velero.io/docs/master/install-requirements
 [10]: http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html
 [11]: https://velero.io/docs/master/faq/

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -1,62 +1,18 @@
-# Velero Backup Storage Locations
+# Backup Storage Location Configurable Parameters
 
-## Backup Storage Location
-
-Velero can store backups in a number of locations. These are represented in the cluster via the `BackupStorageLocation` CRD.
-
-Velero must have at least one `BackupStorageLocation`. By default, this is expected to be named `default`, however the name can be changed by specifying `--default-backup-storage-location` on `velero server`.  Backups that do not explicitly specify a storage location will be saved to this `BackupStorageLocation`.
-
-A sample YAML `BackupStorageLocation` looks like the following:
-
-```yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-  namespace: velero
-spec:
-  provider: aws
-  objectStorage:
-    bucket: myBucket
-  config:
-    region: us-west-2
-    profile: "default"
-```
-
-### Parameter Reference
-
-The configurable parameters are as follows:
-
-#### Main config parameters
+The AWS plugin supports several configurable parameters when defining a `BackupStorageLocation`. These should be provided as key-value pairs to the `velero install` command's `--backup-location-config` flag, or under the `BackupStorageLocation's` `spec.config` field.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String `aws` | Required Field | The name for the AWS cloud provider which will be used to actually store the backups. |
-| `objectStorage` | ObjectStorageLocation | Specification of the object storage for the given provider. |
-| `objectStorage/bucket` | String | Required Field | The storage bucket where backups are to be uploaded. |
-| `objectStorage/prefix` | String | Optional Field | The directory inside a storage bucket where backups are to be uploaded. |
-| `config` | map[string]string<br><br>(See the corresponding [AWS-specific][0] configs documentation.) | None (Optional) | Configuration keys/values to be passed to the cloud provider for backup storage. |
-| `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
-
-
-#### AWS
-
-**(Or other S3-compatible storage)**
-
-##### config
-
-| Key | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
+| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][0] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
 | `s3ForcePathStyle` | bool | `false` | Set this to `true` if you are using a local storage service like Minio. |
 | `s3Url` | string | Required field for non-AWS-hosted storage| *Example*: http://minio:9000<br><br>You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from `region`, and `bucket`. This field is primarily for local storage services like Minio.|
 | `publicUrl` | string | Empty | *Example*: https://minio.mycluster.com<br><br>If specified, use this instead of `s3Url` when generating download URLs (e.g., for logs). This field is primarily for local storage services like Minio.|
 | `serverSideEncryption` | string | Empty | The name of the server-side encryption algorithm to use for uploading objects, e.g. `AES256`. If using SSE-KMS and `kmsKeyId` is specified, this field will automatically be set to `aws:kms` so does not need to be specified by the user. | 
-| `kmsKeyId` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f" or "alias/`<KMS-Key-Alias-Name>`"<br><br>Specify an [AWS KMS key][10] id or alias to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|
+| `kmsKeyId` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f" or "alias/`<KMS-Key-Alias-Name>`"<br><br>Specify an [AWS KMS key][1] id or alias to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|
 | `signatureVersion` | string | `"4"` | Version of the signature algorithm used to create signed URLs that are used by velero cli to download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 4 is correct, but some S3-compatible providers like Quobyte only support version 1.|
 | `profile` | string | "default" | AWS profile within the credential file to use for given store |
 | `insecureSkipTLSVerify` | bool | `false` | Set this to `true` if you do not want to verify the TLS certificate when connecting to the object store--like self-signed certs in Minio. This is susceptible to man-in-the-middle attacks and is not recommended for production. |
 
-[0]: #aws
-[3]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-[10]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html
+[0]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+[1]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -1,18 +1,84 @@
-# Backup Storage Location Configurable Parameters
+# Backup Storage Location
 
-The AWS plugin supports several configurable parameters when defining a `BackupStorageLocation`. These should be provided as key-value pairs to the `velero install` command's `--backup-location-config` flag, or under the `BackupStorageLocation's` `spec.config` field.
+The following sample AWS `BackupStorageLocation` YAML shows all of the configurable parameters. The items under `spec.config` can be provided as key-value pairs to the `velero install` command's `--backup-location-config` flag -- for example, `region=us-east-1,serverSideEncryption=AES256,...`.
 
-| Key | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][0] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
-| `s3ForcePathStyle` | bool | `false` | Set this to `true` if you are using a local storage service like Minio. |
-| `s3Url` | string | Required field for non-AWS-hosted storage| *Example*: http://minio:9000<br><br>You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from `region`, and `bucket`. This field is primarily for local storage services like Minio.|
-| `publicUrl` | string | Empty | *Example*: https://minio.mycluster.com<br><br>If specified, use this instead of `s3Url` when generating download URLs (e.g., for logs). This field is primarily for local storage services like Minio.|
-| `serverSideEncryption` | string | Empty | The name of the server-side encryption algorithm to use for uploading objects, e.g. `AES256`. If using SSE-KMS and `kmsKeyId` is specified, this field will automatically be set to `aws:kms` so does not need to be specified by the user. | 
-| `kmsKeyId` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f" or "alias/`<KMS-Key-Alias-Name>`"<br><br>Specify an [AWS KMS key][1] id or alias to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|
-| `signatureVersion` | string | `"4"` | Version of the signature algorithm used to create signed URLs that are used by velero cli to download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 4 is correct, but some S3-compatible providers like Quobyte only support version 1.|
-| `profile` | string | "default" | AWS profile within the credential file to use for given store |
-| `insecureSkipTLSVerify` | bool | `false` | Set this to `true` if you do not want to verify the TLS certificate when connecting to the object store--like self-signed certs in Minio. This is susceptible to man-in-the-middle attacks and is not recommended for production. |
+```yaml
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  namespace: velero
+spec:
+  # Name of the object store plugin to use to connect to this location.
+  #
+  # Required.
+  provider: velero.io/aws
+  
+  objectStorage:
+    # The bucket in which to store backups.
+    #
+    # Required.
+    bucket: my-bucket
+    
+    # The prefix within the bucket under which to store backups.
+    #
+    # Optional.
+    prefix: my-prefix
+  
+  config:
+    # The AWS region where the bucket is located. Queried from the AWS S3 API if not provided.
+    #
+    # Optional.
+    region: us-east-1
 
-[0]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-[1]: http://docs.aws.amazon.com/kms/latest/developerguide/overview.html
+    # Whether to use path-style addressing instead of virtual hosted bucket addressing. Set to "true"
+    # if using a local storage service like MinIO.
+    #
+    # Optional (defaults to "false").
+    s3ForcePathStyle: "true"
+
+    # You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from 
+    # "region" and "bucket". This field is primarily for local storage services like MinIO.
+    #
+    # Optional.
+    s3Url: "http://minio:9000"
+    
+    # If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This 
+    # field is primarily for local storage services like MinIO.
+    #
+    # Optional.
+    publicUrl: "https://minio.mycluster.com"
+
+    # The name of the server-side encryption algorithm to use for uploading objects, e.g. "AES256".
+    # If using SSE-KMS and "kmsKeyId" is specified, this field will automatically be set to "aws:kms"
+    # so does not need to be specified by the user.
+    #
+    # Optional.
+    serverSideEncryption: AES256
+
+    # Specify an AWS KMS key ID (formatted per the example) or alias (formatted as "alias/<KMS-key-alias-name>")
+    # to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly 
+    # granting key usage rights. 
+    #
+    # Optional.
+    kmsKeyId: "502b409c-4da1-419f-a16e-eif453b3i49f"
+
+    # Version of the signature algorithm used to create signed URLs that are used by velero CLI to 
+    # download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 
+    # 4 is correct, but some S3-compatible providers like Quobyte only support version 1.
+    #
+    # Optional (defaults to "4").
+    signatureVersion: "1"
+
+    # AWS profile within the credentials file to use for the backup storage location.
+    # 
+    # Optional (defaults to "default").
+    profile: "default"
+
+    # Set this to "true" if you do not want to verify the TLS certificate when connecting to the 
+    # object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle 
+    # attacks and is not recommended for production.
+    #
+    # Optional (defaults to "false").
+    insecureSkipTLSVerify: "true"
+```

--- a/volumesnapshotlocation.md
+++ b/volumesnapshotlocation.md
@@ -1,10 +1,27 @@
-# Volume Snapshot Location Configurable Parameters
+# Volume Snapshot Location
 
-The AWS plugin supports several configurable parameters when defining a `VolumeSnapshotLocation`. These should be provided as key-value pairs to the `velero install` command's `--snapshot-location-config` flag, or under the `VolumeSnapshotLocation's` `spec.config` field.
+The following sample AWS `VolumeSnapshotLocation` YAML shows all of the configurable parameters. The items under `spec.config` can be provided as key-value pairs to the `velero install` command's `--snapshot-location-config` flag -- for example, `region=us-east-1,profile=secondary,...`.
 
-| Key | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][0] for the full list.<br><br>Required. |
-| `profile` | string | "default" | AWS profile within the credential file to use for given store |
+```yaml
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  name: aws-default
+  namespace: velero
+spec:
+  # Name of the volume snapshotter plugin to use to connect to this location.
+  #
+  # Required.
+  provider: velero.io/aws
+  
+  config:
+    # The AWS region where the volumes/snapshots are located.
+    #
+    # Required.
+    region: us-east-1
 
-[0]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+    # AWS profile within the credentials file to use for the volume snapshot location.
+    # 
+    # Optional (defaults to "default").
+    profile: "default"
+```

--- a/volumesnapshotlocation.md
+++ b/volumesnapshotlocation.md
@@ -1,47 +1,10 @@
-# Velero Volume Snapshot Location
+# Volume Snapshot Location Configurable Parameters
 
-## Volume Snapshot Location
-
-A volume snapshot location is the location in which to store the volume snapshots created for a backup.
-
-Velero can be configured to take snapshots of volumes from multiple providers. Velero also allows you to configure multiple possible `VolumeSnapshotLocation` per provider, although you can only select one location per provider at backup time.
-
-Each VolumeSnapshotLocation describes a provider + location. These are represented in the cluster via the `VolumeSnapshotLocation` CRD. Velero must have at least one `VolumeSnapshotLocation` per cloud provider.
-
-A sample YAML `VolumeSnapshotLocation` looks like the following:
-
-```yaml
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: aws-default
-  namespace: velero
-spec:
-  provider: aws
-  config:
-    region: us-west-2
-    profile: "default"
-```
-
-### Parameter Reference
-
-The configurable parameters are as follows:
-
-#### Main config parameters
+The AWS plugin supports several configurable parameters when defining a `VolumeSnapshotLocation`. These should be provided as key-value pairs to the `velero install` command's `--snapshot-location-config` flag, or under the `VolumeSnapshotLocation's` `spec.config` field.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String `aws`. | Required Field | The name of the AWS cloud provider which will be used to actually store the volume. |
-| `config` | See the corresponding [AWS-specific][0] configs or the provider's documentation.
-
-#### AWS
-
-##### config
-
-| Key | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Required. |
+| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][0] for the full list.<br><br>Required. |
 | `profile` | string | "default" | AWS profile within the credential file to use for given store |
 
-[0]: #aws
-[3]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+[0]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

PR 2 of 4 for https://github.com/vmware-tanzu/velero/issues/2003 -- also see https://github.com/vmware-tanzu/velero/pull/2046 for related changes in the main velero repo.

Once we're happy with this, I'll make similar changes for the Azure and GCP repos.

cc @carlisia @nrb @prydonius 