### PR TITLE
fix indenting on make push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ container:
 # push pushes the Docker image to its registry.
 push:
 	@docker push $(IMAGE):$(VERSION)
-	ifeq ($(TAG_LATEST), true)
-		docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
-		docker push $(IMAGE):latest
-	endif
+ifeq ($(TAG_LATEST), true)
+	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
+	docker push $(IMAGE):latest
+endif
 
 # build-dirs creates the necessary directories for a build in the local environment.
 build-dirs:


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Forgot that indenting is funky in Makefiles...fixes the broken build. I tested this locally by pushing to my personal repo.

cc @carlisia @nrb @prydonius 