### PR TITLE
Add support for availability zone override during restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ Copy one of the returned IDs `<ID>` and use it with the `aws` CLI tool to search
     aws ec2 describe-tags --filters "Name=resource-id,Values=<ID>" "Name=key,Values=KubernetesCluster"
     ```
 
+### Overriding AWS Availability Zone (optional)
+
+Add the environment variable `VELERO_AWS_AZ_OVERRIDE` under `spec.template.spec.env` to force EBS volumes to be restored into the provided AWS availability zone.
+This is helpful when migrating persistent volumes across clusters, as by default Velero will restore them into the AZ that the original EBS volume resided in.
 
 [1]: #Create-S3-bucket
 [2]: #Set-permissions-for-Velero

--- a/changelogs/unreleased/00002-pbar1.md
+++ b/changelogs/unreleased/00002-pbar1.md
@@ -1,0 +1,5 @@
+- Introduce environment variable `VELERO_AWS_AZ_OVERRIDE`
+    - Changed VolumeSnapshotter restores EBS volumes from snapshots into the
+      override availability zone if set
+    - Added RestoreItemAction to rewrite Persistent Volume availability zone
+      to the override value

--- a/velero-plugin-for-aws/main.go
+++ b/velero-plugin-for-aws/main.go
@@ -27,6 +27,7 @@ func main() {
 		BindFlags(pflag.CommandLine).
 		RegisterObjectStore("velero.io/aws", newAwsObjectStore).
 		RegisterVolumeSnapshotter("velero.io/aws", newAwsVolumeSnapshotter).
+		RegisterRestoreItemAction("velero.io/aws", newAwsRestorePlugin).
 		Serve()
 }
 
@@ -36,4 +37,8 @@ func newAwsObjectStore(logger logrus.FieldLogger) (interface{}, error) {
 
 func newAwsVolumeSnapshotter(logger logrus.FieldLogger) (interface{}, error) {
 	return newVolumeSnapshotter(logger), nil
+}
+
+func newAwsRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return newRestorePlugin(logger), nil
 }

--- a/velero-plugin-for-aws/restoreplugin.go
+++ b/velero-plugin-for-aws/restoreplugin.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2017, 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	envAZOverride = "VELERO_AWS_AZ_OVERRIDE"
+	labelZoneBeta = "failure-domain.beta.kubernetes.io/zone"
+	labelZone     = "topology.kubernetes.io/zone"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	log logrus.FieldLogger
+}
+
+func newRestorePlugin(logger logrus.FieldLogger) *RestorePlugin {
+	return &RestorePlugin{log: logger}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+// A RestoreItemAction's Execute function will only be invoked on items that match the returned
+// selector. A zero-valued ResourceSelector matches all resources.g
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"persistentvolume"},
+	}, nil
+}
+
+// Execute allows the RestorePlugin to perform arbitrary logic with the item being restored,
+// in this case, overwriting AWS availability zone settings within Persistent Volumes.
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.log.Info("AWS RestorePlugin")
+
+	overrideAZ := os.Getenv(envAZOverride)
+	if overrideAZ == "" {
+		p.log.Infof("%s not found, using existing AZ for PV", envAZOverride)
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
+	p.log.Infof("variable %s found, overriding to: %s", envAZOverride, overrideAZ)
+
+	metadata, err := meta.Accessor(input.Item)
+	if err != nil {
+		return &velero.RestoreItemActionExecuteOutput{}, err
+	}
+
+	labels := metadata.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, ok := labels[labelZoneBeta]; ok {
+		labels[labelZoneBeta] = overrideAZ
+	}
+	if _, ok := labels[labelZone]; ok {
+		labels[labelZone] = overrideAZ
+	}
+
+	metadata.SetLabels(labels)
+
+	var pv corev1api.PersistentVolume
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &pv); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if ebs := pv.Spec.AWSElasticBlockStore; ebs != nil {
+		tmp := strings.Split(ebs.VolumeID, "/")
+		tmp[2] = overrideAZ
+		ebs.VolumeID = strings.Join(tmp, "/")
+	}
+
+	if na := pv.Spec.NodeAffinity; na != nil {
+		if r := na.Required; r != nil {
+			if nst := r.NodeSelectorTerms; nst != nil {
+				for i := range nst {
+					if nst[i].MatchExpressions != nil {
+						for j := range nst[i].MatchExpressions {
+							if (nst[i].MatchExpressions[j].Key == labelZoneBeta || nst[i].MatchExpressions[j].Key == labelZone) && nst[i].MatchExpressions[j].Operator == "In" {
+								p.log.Infof("Current node affinity set to %s, overriding to %s", nst[i].MatchExpressions[j].Values[0], overrideAZ)
+								nst[i].MatchExpressions[j].Values = []string{overrideAZ}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	inputMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pv)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: inputMap}), nil
+}

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -104,6 +104,12 @@ func (b *VolumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, volumeType, vol
 		return "", errors.Errorf("expected 1 snapshot from DescribeSnapshots for %s, got %v", snapshotID, count)
 	}
 
+	overrideAZ := os.Getenv(envAZOverride)
+	if overrideAZ != "" {
+		b.log.Infof("variable %s found, restoring volume from snapshot in: %s", envAZOverride, overrideAZ)
+		volumeAZ = overrideAZ
+	}
+
 	// filter tags through getTagsForCluster() function in order to apply
 	// proper ownership tags to restored volumes
 	req := &ec2.CreateVolumeInput{


### PR DESCRIPTION
I split this commit history into two commits to reduce noise:
- Migrate from `dep` to `go mod` for dependency management (I can remove this it's too large of a change, but I can confirm that it just works perfectly!)
- Introduce environment variable `VELERO_AWS_AZ_OVERRIDE`
    - Changed VolumeSnapshotter restores EBS volumes from snapshots into the
      override availability zone if set
    - Added RestoreItemAction to rewrite Persistent Volume availability zone
      to the override value

I've built using `make container` and pushed the resulting image to our internal registry, and have tested that it functions correctly. Without setting the envrionment variable, the plugin functions as before. With it set, restores are successful in the override AZ.

Thanks for all your hard work! The plugin works great, and helps us tremendously to achieve our goals. Let me know if there is anything else I can do to help out.