### PR TITLE
bind flags to support --log-level

### DIFF
--- a/changelogs/unreleased/31-skriss
+++ b/changelogs/unreleased/31-skriss
@@ -1,0 +1,1 @@
+bug fix: have plugin server bind flags to allow --log-level flag to be used

--- a/velero-plugin-for-aws/main.go
+++ b/velero-plugin-for-aws/main.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	veleroplugin "github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
 
 func main() {
 	veleroplugin.NewServer().
+		BindFlags(pflag.CommandLine).
 		RegisterObjectStore("velero.io/aws", newAwsObjectStore).
 		RegisterVolumeSnapshotter("velero.io/aws", newAwsVolumeSnapshotter).
 		Serve()


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

This enables the `--log-level` flag that's passed from the main velero process to actually be respected.