### PR TITLE
Update object store plugin to respect proxy environment

### DIFF
--- a/changelogs/unreleased/00037-dymurray.md
+++ b/changelogs/unreleased/00037-dymurray.md
@@ -1,0 +1,1 @@
+Pull in proxy configuration from environment when constructing custom transport

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -144,9 +144,20 @@ func (o *ObjectStore) Init(config map[string]string) error {
 	}
 
 	if insecureSkipTLSVerify {
+		defaultTransport := http.DefaultTransport.(*http.Transport)
 		serverConfig.HTTPClient = &http.Client{
+			// Copied from net/http
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				Proxy:                 defaultTransport.Proxy,
+				DialContext:           defaultTransport.DialContext,
+				MaxIdleConns:          defaultTransport.MaxIdleConns,
+				IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+				TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+				ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+				// Set insecureSkipVerify true
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
 			},
 		}
 	}


### PR DESCRIPTION
We should also be using the default transport settings to get sane timeout vars rather than using a new transport struct.