### PR TITLE
Reuse the aws session with cacerts and credentials for fetching region

### DIFF
--- a/velero-plugin-for-aws/helpers.go
+++ b/velero-plugin-for-aws/helpers.go
@@ -18,7 +18,11 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -26,20 +30,148 @@ import (
 	"github.com/pkg/errors"
 )
 
+// S3Config holds all the configuration params passed
+type S3Config struct {
+	region                   string
+	s3URL                    string
+	publicURL                string
+	kmsKeyID                 string
+	s3ForcePathStyleVal      string
+	signatureVersion         string
+	credentialProfile        string
+	serverSideEncryption     string
+	insecureSkipTLSVerifyVal string
+	bucket                   string
+	caCert                   string
+	session                  *session.Session
+	publicSession            *session.Session
+}
+
+// NewS3Config returns an instance of the config loaded from by the plugin framework
+func NewS3Config(cfg map[string]string) *S3Config {
+	return &S3Config{
+		region:                   cfg[regionKey],
+		s3URL:                    cfg[s3URLKey],
+		publicURL:                cfg[publicURLKey],
+		kmsKeyID:                 cfg[kmsKeyIDKey],
+		s3ForcePathStyleVal:      cfg[s3ForcePathStyleKey],
+		signatureVersion:         cfg[signatureVersionKey],
+		credentialProfile:        cfg[credentialProfileKey],
+		serverSideEncryption:     cfg[serverSideEncryptionKey],
+		insecureSkipTLSVerifyVal: cfg[insecureSkipTLSVerifyKey],
+		bucket:                   cfg[bucketKey],
+		caCert:                   cfg[caCertKey],
+	}
+}
+
+// Init initializes the S3 config parameters which needs to be fetched/prepared based on the passed options
+func (h *S3Config) Init() error {
+	// AWS (not an alternate S3-compatible API) and region not
+	// explicitly specified: determine the bucket's region
+	var (
+		s3ForcePathStyle      bool
+		insecureSkipTLSVerify bool
+		err                   error
+	)
+	if h.s3ForcePathStyleVal != "" {
+		if s3ForcePathStyle, err = strconv.ParseBool(h.s3ForcePathStyleVal); err != nil {
+			return errors.Wrapf(err, "could not parse %s (expected bool)", s3ForcePathStyleKey)
+		}
+	}
+
+	// prepares the AWS Sessions with the session-config having only known parameters.
+	// Any unknown or derived params will be added further to the initialization
+	if err = h.initAWSSessions(s3ForcePathStyle); err != nil {
+		return errors.Wrap(err, "could not initialize AWS session")
+	}
+
+	// add region to the session config
+	if h.s3URL == "" && h.region == "" {
+		h.region, err = h.getBucketRegion()
+		if err != nil {
+			return err
+		}
+
+		h.session.Config = h.session.Config.WithRegion(h.region)
+	}
+
+	// add insecure flag to the http transport config in http client and add it to the session config
+	if h.insecureSkipTLSVerifyVal != "" {
+		if insecureSkipTLSVerify, err = strconv.ParseBool(h.insecureSkipTLSVerifyVal); err != nil {
+			return errors.Wrapf(err, "could not parse %s (expected bool)", insecureSkipTLSVerifyKey)
+		}
+	}
+
+	if insecureSkipTLSVerify {
+		defaultTransport := http.DefaultTransport.(*http.Transport)
+		h.session.Config.HTTPClient = &http.Client{
+			// Copied from net/http
+			Transport: &http.Transport{
+				Proxy:                 defaultTransport.Proxy,
+				DialContext:           defaultTransport.DialContext,
+				MaxIdleConns:          defaultTransport.MaxIdleConns,
+				IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+				TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+				ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+				// Set insecureSkipVerify true
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+func (h *S3Config) initAWSSessions(s3ForcePathStyle bool) error {
+	cfg, err := newAWSConfig(h.s3URL, h.region, s3ForcePathStyle)
+	if err != nil {
+		return err
+	}
+
+	sessionOptions := session.Options{Config: *cfg, Profile: h.credentialProfile}
+	if len(h.caCert) > 0 {
+		sessionOptions.CustomCABundle = strings.NewReader(h.caCert)
+	}
+
+	h.session, err = getSession(sessionOptions)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// init public session
+	if h.publicURL != "" {
+		pcfg, err := newAWSConfig(h.publicURL, h.region, s3ForcePathStyle)
+		if err != nil {
+			return err
+		}
+
+		sessionOptions = session.Options{Config: *pcfg, Profile: h.credentialProfile}
+		if len(h.caCert) > 0 {
+			sessionOptions.CustomCABundle = strings.NewReader(h.caCert)
+		}
+
+		h.publicSession, err = getSession(sessionOptions)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
 // GetBucketRegion returns the AWS region that a bucket is in, or an error
 // if the region cannot be determined.
-func GetBucketRegion(bucket string) (string, error) {
+func (h *S3Config) getBucketRegion() (string, error) {
 	var region string
-
-	session, err := session.NewSession()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
+	var fErr error
 
 	for _, partition := range endpoints.DefaultPartitions() {
 		for regionHint := range partition.Regions() {
-			region, _ = s3manager.GetBucketRegion(context.Background(), session, bucket, regionHint)
-
+			var err error
+			region, err = s3manager.GetBucketRegion(context.Background(), h.session, h.bucket, regionHint)
+			fErr = errors.Wrap(err, "")
 			// we only need to try a single region hint per partition, so break after the first
 			break
 		}
@@ -49,7 +181,7 @@ func GetBucketRegion(bucket string) (string, error) {
 		}
 	}
 
-	return "", errors.New("unable to determine bucket's region")
+	return "", errors.Wrap(fErr, "unable to determine bucket's region")
 }
 
 // IsValidS3URLScheme returns true if the scheme is http:// or https://

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -48,19 +48,6 @@ type VolumeSnapshotter struct {
 	ec2 *ec2.EC2
 }
 
-// takes AWS session options to create a new session
-func getSession(options session.Options) (*session.Session, error) {
-	sess, err := session.NewSessionWithOptions(options)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if _, err := sess.Config.Credentials.Get(); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return sess, nil
-}
-
 func newVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 	return &VolumeSnapshotter{log: logger}
 }
@@ -70,6 +57,8 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 		return err
 	}
 
+	// region and profile are 'Required' fields in the VolumeSnapshot CR,
+	// hence it is safe to assume that they will be present in the config and we dont have to find it on the runtime
 	region := config[regionKey]
 	credentialProfile := config[credentialProfileKey]
 	if region == "" {


### PR DESCRIPTION
Velero has a way to use custom CA bundle to access the objectStore behind the proxy by providing the option `--cacerts` at the time of velero install or velero client operations.

s3 plugin tries to communicate the objectStore for finding out the region or to push/pull the Backup manifests. If the region is not provided in the BackupStorageLocation config, while finding the region, plugin creates a new aws session config which doesnot use any session options, such as certs or credential profile.

This PR is to add the support for aws s3 plugin also to consume the ca certificate bundle passed in `BackupStorageLocation` with the `caCerts` field.

This can be tested by having a velero setup behind proxy with a sef-signed certs and pass them along with the velero install and try to perform the backup/restore operations

Fixes: [vmware-tanzu/velero#3449](https://github.com/vmware-tanzu/velero/issues/3449)

Signed-off-by: Ayush Rangwala arangwala@vmware.com