### PR TITLE
Only publish the container image from the root repo

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Test
       run: make test
 
+    # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
     - name: Publish container image
+      if: github.repository == 'vmware-tanzu/velero-plugin-for-aws'
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh


### PR DESCRIPTION
Only try to publish the container image from the root repo `vmware-tanzu/velero-plugin-for-aws`.
The forked repo doesn't have permission to do so and will always get failures.
