### PR TITLE
Add possibility to assume a role for cross account connectivity

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -50,6 +50,15 @@ spec:
     #
     # Optional.
     s3Url: "http://minio:9000"
+
+    # If specified, the plugin will use the current role to assume this one.
+    # This is only used for the upload to the S3 bucket, it is not used for
+    # volume snapshotting.
+    # This assumed role is useful to upload in a bucket located in a different
+    # AWS account.
+    #
+    # Optional.
+    s3AssumeRole: ""
     
     # If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This 
     # field is primarily for local storage services like MinIO.

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -74,7 +74,7 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 		return err
 	}
 
-	sess, err := getSession(sessionOptions)
+	sess, err := getSession(sessionOptions, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The purpose of this is to be able to use a Web Identity token to write in a bucket located in a different AWS account.

The token is linked to a role which has no S3 capabilities but can assume another role in a different account that can manage S3 buckets.