### PR TITLE
add support for AWS EBS CSI Driver

### DIFF
--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -269,12 +269,17 @@ func (b *VolumeSnapshotter) GetVolumeID(unstructuredPV runtime.Unstructured) (st
 		return "", errors.WithStack(err)
 	}
 
-	if pv.Spec.AWSElasticBlockStore == nil {
+	if pv.Spec.AWSElasticBlockStore == nil && pv.Spec.CSI == nil {
 		return "", nil
 	}
 
-	if pv.Spec.AWSElasticBlockStore.VolumeID == "" {
-		return "", errors.New("spec.awsElasticBlockStore.volumeID not found")
+	// VolumeHandle is implicit to the ebs.csi.aws.com driver
+	if pv.Spec.AWSElasticBlockStore.VolumeID == "" && pv.Spec.CSI.VolumeHandle == "" {
+		return "", errors.New("spec.awsElasticBlockStore.volumeID and spec.csi.volumeHandle not found")
+	}
+
+	if pv.Spec.CSI.Driver == "ebs.csi.aws.com" {
+		return ebsVolumeIDRegex.FindString(pv.Spec.CSI.VolumeHandle), nil
 	}
 
 	return ebsVolumeIDRegex.FindString(pv.Spec.AWSElasticBlockStore.VolumeID), nil
@@ -286,8 +291,8 @@ func (b *VolumeSnapshotter) SetVolumeID(unstructuredPV runtime.Unstructured, vol
 		return nil, errors.WithStack(err)
 	}
 
-	if pv.Spec.AWSElasticBlockStore == nil {
-		return nil, errors.New("spec.awsElasticBlockStore not found")
+	if pv.Spec.AWSElasticBlockStore == nil && pv.Spec.CSI == nil {
+		return nil, errors.New("spec.awsElasticBlockStore or spec.csi not found")
 	}
 
 	pvFailureDomainZone := pv.Labels["failure-domain.beta.kubernetes.io/zone"]

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -271,7 +271,6 @@ func (b *VolumeSnapshotter) GetVolumeID(unstructuredPV runtime.Unstructured) (st
 
 	// check for CSI driver
 	if pv.Spec.CSI.Driver == "ebs.csi.aws.com" {
-		println(pv.Spec.CSI.VolumeHandle)
 		return ebsVolumeIDRegex.FindString(pv.Spec.CSI.VolumeHandle), nil
 	}
 


### PR DESCRIPTION
Currently, this plugin only supports volume snapshots of awsElasticBlockStore which includes volume types such as gp2. The plugin doesn't account for gp3 volume types and newer ones that are provided by the [AWS EBS CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver). This change introduces a check for the `csi` key in the `spec` section of the persistent volume object.