### PR TITLE
Add SSE-C encryption support

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -60,8 +60,18 @@ spec:
     # to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly 
     # granting key usage rights. 
     #
+    # Cannot be used in conjunction with customerKeyEncryptionFile.
+    #
     # Optional.
     kmsKeyId: "502b409c-4da1-419f-a16e-eif453b3i49f"
+    
+    # Specify the file that contains the SSE-C customer key to enable customer key encryption of the backups
+    # stored in S3. The referenced file should contain a 32-byte string.
+    #
+    # Cannot be used in conjunction with kmsKeyId.
+    #
+    # Optional (defaults to "", which means SSE-C is disabled).
+    customerKeyEncryptionFile: "/credentials/customer-key"
 
     # Version of the signature algorithm used to create signed URLs that are used by velero CLI to 
     # download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 

--- a/changelogs/unreleased/096-StevenReitsma
+++ b/changelogs/unreleased/096-StevenReitsma
@@ -1,0 +1,1 @@
+Add SSE-C encryption support


### PR DESCRIPTION
Signed-off-by: Steven Reitsma <steven@reitsma.io>

The way this works is as follows:
- The user has to add an additional parameter `customerKeyEncryptionFile` to their `BackupStorageLocation` as shown in `backupstoragelocation.md`. This parameter points to a file that should contain a 32-byte SSE-C encryption key.
- The user has to mount a Secret in the Velero pod to this path. However, since Helm already mounts a credentials Secret I decided to just add an additional key to it. This way, no additional changes are needed except for the `values.yaml` that creates the Secret. An example in Helm:
```
velero:
  credentials:
    useSecret: true
    name: s3-credentials
    secretContents:
      customer-key: v9jBJlepg8Z7ezyUiFyS7LwpRWZYRMLN
      cloud: |
        [default]
        aws_access_key_id=foo
        aws_secret_access_key=bar
```
I can also send a PR to [vmware-tanzu/helm-charts](https://github.com/vmware-tanzu/helm-charts) to document this in the `values.yaml`.