### PR TITLE
Add actions that sync images to GCR

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,3 +55,16 @@ jobs:
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh
+
+    # Use the JSON key in secret to login gcr.io
+    - uses: 'docker/login-action@v1'
+      with:
+        registry: 'gcr.io' # or REGION.docker.pkg.dev
+        username: '_json_key'
+        password: '${{ secrets.GCR_SA_KEY }}'
+
+    # Push image to GCR to facilitate some environments that have rate limitation to docker hub, e.g. vSphere.
+    - name: Publish container image to GCR
+      if: github.repository == 'vmware-tanzu/velero-plugin-for-aws'
+      run: |
+        REGISTRY=gcr.io/velero-gcp ./hack/docker-push.sh

--- a/changelogs/unreleased/112-jxun
+++ b/changelogs/unreleased/112-jxun
@@ -1,0 +1,1 @@
+Add actions that sync images to GCR


### PR DESCRIPTION
This is used for facilitating some environments that have rate limitation to docker hub, e.g. vSphere.

Signed-off-by: Xun Jiang <jxun@vmware.com>