### PR TITLE
Fix bug that the iops was not being populated for io2

### DIFF
--- a/changelogs/unreleased/119-stevefraser
+++ b/changelogs/unreleased/119-stevefraser
@@ -1,0 +1,1 @@
+Fixing bug for io2 that caused the iops to not be populated

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -44,7 +44,7 @@ const (
 // iopsVolumeTypes is a set of AWS EBS volume types for which IOPS should
 // be captured during snapshot and provided when creating a new volume
 // from snapshot.
-var iopsVolumeTypes = sets.NewString("io1,io2")
+var iopsVolumeTypes = sets.NewString("io1","io2")
 
 type VolumeSnapshotter struct {
 	log logrus.FieldLogger

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -44,7 +44,7 @@ const (
 // iopsVolumeTypes is a set of AWS EBS volume types for which IOPS should
 // be captured during snapshot and provided when creating a new volume
 // from snapshot.
-var iopsVolumeTypes = sets.NewString("io1")
+var iopsVolumeTypes = sets.NewString("io1,io2")
 
 type VolumeSnapshotter struct {
 	log logrus.FieldLogger


### PR DESCRIPTION
It seem that for Io2 the IOPs paramter is getting dropped.

```
Errors:
  Velero:     <none>
  Cluster:  error executing PVAction for persistentvolumes/pvc-766a528b-aa91-46c1-87cd-61c306cfab22: rpc error: code = Unknown desc = InvalidParameterCombination: The parameter iops must be specified for io2 volumes.
  status code: 400, request id: 7f62132d-f88a-4488-afaa-dcfe30a905df
    error executing PVAction for persistentvolumes/pvc-fcb41884-bb32-43b1-bbb1-f6ccb0028056: rpc error: code = Unknown desc = InvalidParameterCombination: The parameter iops must be specified for io2 volumes.
  status code: 400, request id: dc796934-4c99-4a2c-8127-cb5a54eff7f9
  Namespaces: <none>
```

Io2 requires the OPS value according to the documentation provided 
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#CreateVolumeInput

```
	// The number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
	// this represents the number of IOPS that are provisioned for the volume. For gp2
	// volumes, this represents the baseline performance of the volume and the rate at
	// which the volume accumulates I/O credits for bursting. The following are the
	// supported values for each volume type:
	//
	// * gp3: 3,000-16,000 IOPS
	//
	// * io1:
	// 100-64,000 IOPS
	//
	// * io2: 100-64,000 IOPS
	//
	// io1 and io2 volumes support up to
	// 64,000 IOPS only on Instances built on the Nitro System
	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
	// Other instance families support performance up to 32,000 IOPS. This parameter is
	// required for io1 and io2 volumes. The default for gp3 volumes is 3,000 IOPS.
	// This parameter is not supported for gp2, st1, sc1, or standard volumes.
```

I have added io2 to the list to keep the iops value for. 
