### PR TITLE
Remove Dave and Ming from the autoassignees

### DIFF
--- a/.github/auto-assignees.yml
+++ b/.github/auto-assignees.yml
@@ -9,12 +9,10 @@ reviewers:
 
   groups:
     maintainers:
-      - dsu-igeek
       - sseago
       - reasonerjt
       - ywk253100
       - blackpiglet
-      - qiuming-best
 
 options:
   ignore_draft: true


### PR DESCRIPTION
They will remain as maintainers of velero project but will not be
assigned to review the PRs for AWS plugin.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>