### PR TITLE
Update go build version?

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,10 +6,10 @@ jobs:
     name: Run CI
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Go 1.17
+    - name: Setup Go 1.17.11
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.17.11
       id: go
 
     - name: Check out the code

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,10 +6,10 @@ jobs:
     name: Run CI
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Go 1.17.11
+    - name: Setup Go 1.17.13
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.17.13
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.11
+        go-version: 1.17.13
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.17.11
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.17.11-buster AS build
+FROM --platform=$BUILDPLATFORM golang:1.17.13-buster AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.17-buster AS build
+FROM --platform=$BUILDPLATFORM golang:1.17.11-buster AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
We use continuous scanning with tools to scan our hardened images. We are encountering a number of CVEs regarding go1.17.11. Will there be a future release updating go version? Let me know if you need more information about the CVEs.