### PR TITLE
Pin the Golang version to 1.18.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,10 +6,10 @@ jobs:
     name: Run CI
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Go 1.18
+    - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.8
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18.8
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.18-buster AS build
+FROM --platform=$BUILDPLATFORM golang:1.18.8-buster AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Pin the Golang version to 1.18.8 for v1.6.0

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>