### PR TITLE
Remove linux/ppc64le to fix publish issue

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,6 +66,7 @@ jobs:
       if: github.repository == 'vmware-tanzu/velero-plugin-for-aws'
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+        # Call `docker-push.sh` to push the velero-plugin-for-aws image to dockerhub 
         VERSION=$(./hack/docker-push.sh | grep 'VERSION:' | awk -F: '{print $2}' | xargs)
 
         # Upload velero-plugin-for-aws image package to GCS

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -77,7 +77,7 @@ else
 fi
 
 if [[ -z "$BUILDX_PLATFORMS" ]]; then
-    BUILDX_PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+    BUILDX_PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
 fi
 
 # Debugging info


### PR DESCRIPTION
This commit removes the "linux/ppc64le" from BUILDX_PLATFORMS as the image busybox:1.34.1-uclibc does not support it.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>