### PR TITLE
add aws tags to objects in s3

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -98,4 +98,9 @@ spec:
     # Optional (defaults to "false").
     enableSharedConfig: "true"
 
+    # Tags that need to be placed on AWS S3 objects. 
+    # For example "Key1=Value1&Key2=Value2"
+    # Optional (defaults to empty "")
+    tagging: ""
+
 ```

--- a/velero-plugin-for-aws/helpers.go
+++ b/velero-plugin-for-aws/helpers.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -63,4 +64,29 @@ func IsValidS3URLScheme(s3URL string) bool {
 		return false
 	}
 	return true
+}
+
+func CheckTags(tagging string) error {
+	tags := strings.Split(tagging, "&")
+	if len(tags) == 1 {
+		return errors.New("Tags are not seperated with an &")
+	}
+	for c, j := range tags {
+		if c > 9 {
+			return errors.New("Aws S3 allows only ten tags per object")
+		}
+		tg := strings.Split(j, "=")
+		if len(tg) != 2 {
+			return errors.New("invalid tags provided")
+		} else {
+			if len([]rune(tg[0])) > 128 {
+				return errors.New("An S3 tag key can not be more than 128 Unicode characters in length")
+			} else {
+				if len([]rune(tg[1])) > 248 {
+					return errors.New("An S3 tag values can not be more 256 Unicode characters in length")
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/velero-plugin-for-aws/helpers_test.go
+++ b/velero-plugin-for-aws/helpers_test.go
@@ -28,3 +28,11 @@ func TestS3URL(t *testing.T) {
 	assert.False(t, IsValidS3URLScheme("httpd://foo"))
 	assert.False(t, IsValidS3URLScheme(""))
 }
+
+func TestS3Tags(t *testing.T) {
+	assert.Error(t, CheckTags("96FrFmTtJcBkEYEVtS3Bxrv2E37KG9m3M9CJqbtVCw7gy4UBEvpBC4h6xdV7FUBag7XeZhccvQuY8AgERdeWafBZRR7NRb8BnA6CkcqDHPpPPFpwLzXenjxZmeRK6J9hty=Value1&Key2=Value2&Key3=Value3"))
+	assert.Error(t, CheckTags("Key1=Value1&Key2=tka2MYGaFegMVkdm5nC58D46dyXCDbKcXnCZNrCHyS6s8TtMacs9HFXpGCNr2PVntCHArkKbgyYntVhBn2AAJXdKkvA9jdRrc4vCsYzCSZ4ZhCR7PBaKgMMdTtz93jRZNNFJcAqzrybDqCEmtKfFj3MdxLSvjej9tqP8bUt66449ZCbPuk8b7ASrYkPf6fQVYXM9rbmtyzWbhxtYdZs7nUaE4pQqtEfggqSEGbNaNWSf6x6vjUVJ2fAsZNfwKMxUwe"))
+	assert.Error(t, CheckTags("Key1=Value1&Key2=Value2&Key3-Value3&Key4=Value4&Key5=Value5&Key6=Value6&Key7=Value7&Key8=Value8&Key9=Value9&key10=Value10&Key11=Value11"))
+	assert.Nil(t, CheckTags("Key1=Value1,Key2=Value2"))
+	assert.ErrorIs(t, CheckTags("Key1=Value1&Key2=Value2&Key3=Value3"), nil)
+}


### PR DESCRIPTION
This PR allows to tag objects put to s3 by velero. 
Issue: Add capability to tag objects put in S3 #6309