### PR TITLE
[main-branch] fallback to env variable for credentials file

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -271,6 +271,10 @@ func newSessionOptions(config aws.Config, profile, caCert, credentialsFile, enab
 		sessionOptions.CustomCABundle = strings.NewReader(caCert)
 	}
 
+	if credentialsFile == "" && os.Getenv("AWS_SHARED_CREDENTIALS_FILE") != "" {
+		credentialsFile = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	}
+
 	if credentialsFile != "" {
 		if _, err := os.Stat(credentialsFile); err != nil {
 			if os.IsNotExist(err) {


### PR DESCRIPTION
This commit makes plugin read the path from environment var for credentials files and shared config file if it's not set in the spec of BSL.