### PR TITLE
Update backupstoragelocation.md SSE-C

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -67,7 +67,12 @@ spec:
     
     # Specify the file that contains the SSE-C customer key to enable customer key encryption of the backups
     # stored in S3. The referenced file should contain a 32-byte string.
-    #
+    #  
+    # The customerKeyEncryptionFile points to a mounted secret within the velero container.
+    # Add the below values to the velero cloud-credentials secret:
+    # customer-key: <your_b64_encoded_32byte_string>
+    # The default value below points to the already mounted secret.
+    # 
     # Cannot be used in conjunction with kmsKeyId.
     #
     # Optional (defaults to "", which means SSE-C is disabled).


### PR DESCRIPTION
* During setup of SSE-C I discovered strange behavior and unclear documentation on how to configure SSE-C
* I read the code where SSE-C came in #96 and updated the description so other people get a chance to understand how this works. The Author of #96 implemented this for Helm Charts as far as I understood, but when using `velero install` instead of helm, things get confusing on how to setup SSE-C properly. 
* I assumed that the referenced file `customerKeyEncryptionFile` transforms into a secret when used with `velero install` like the `secret-file` file which holds the S3 creds. But instead its referencing the path to the secret from the within the velero pod. 