### PR TITLE
Add label org.opencontainers.image.source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN export GOARM=$( echo "${GOARM}" | cut -c2-) && \
     CGO_ENABLED=0 go build -v -o /go/bin/velero-plugin-for-aws ./velero-plugin-for-aws && \
     CGO_ENABLED=0 go build -v -o /go/bin/cp-plugin ./hack/cp-plugin
 FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/vmware-tanzu/velero-plugin-for-aws"
 COPY --from=build /go/bin/velero-plugin-for-aws /plugins/
 COPY --from=build /go/bin/cp-plugin /bin/cp-plugin
 USER 65532:65532


### PR DESCRIPTION
Dependency bots, like renovate, use the label `org.opencontainers.image.source` in order to show the release notes from a GitHub release in a PR with a container update.
This allows the user to efficiently update container images without the need to search for the release notes or jump to the repository.

Add the label `org.opencontainers.image.source="https://github.com/vmware-tanzu/velero-plugin-for-aws"` to the container image.
This helps for example Renovate to add Release Notes to PRs that update the container image.
https://docs.renovatebot.com/modules/datasource/docker/