### PR TITLE
Respect the TLS setting in BSL in object store plugin

### DIFF
--- a/velero-plugin-for-aws/helpers.go
+++ b/velero-plugin-for-aws/helpers.go
@@ -17,35 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"net/url"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pkg/errors"
 )
-
-// GetBucketRegion returns the AWS region that a bucket is in, or an error
-// if the region cannot be determined.
-func GetBucketRegion(bucket string, usePathStyle bool) (string, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background())
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	client := s3.NewFromConfig(cfg)
-	region, err := s3manager.GetBucketRegion(context.Background(), client, bucket, func(o *s3.Options) {
-		o.UsePathStyle = usePathStyle
-	})
-	if err != nil {
-		return "", err
-	}
-	if region == "" {
-		return "", errors.New("unable to determine bucket's region")
-	}
-	return region, nil
-}
 
 // IsValidS3URLScheme returns true if the scheme is http:// or https://
 // and the url parses correctly, otherwise, return false

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -127,24 +128,37 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		}
 	}
 
-	// AWS (not an alternate S3-compatible API) and region not
-	// explicitly specified: determine the bucket's region
-	if s3URL == "" && region == "" {
-		var err error
-		region, err = GetBucketRegion(bucket, s3ForcePathStyle)
-		if err != nil {
-			o.log.Errorf("Failed to get bucket region, bucket: %s, error: %v", bucket, err)
-			return err
-		}
-	}
-
 	if insecureSkipTLSVerifyVal != "" {
 		if insecureSkipTLSVerify, err = strconv.ParseBool(insecureSkipTLSVerifyVal); err != nil {
 			return errors.Wrapf(err, "could not parse %s (expected bool)", insecureSkipTLSVerifyKey)
 		}
 	}
 
-	cfg, err := newAWSConfig(region, credentialProfile, credentialsFile, insecureSkipTLSVerify, caCert)
+	// AWS (not an alternate S3-compatible API) and region not
+	// explicitly specified: determine the bucket's region
+	if s3URL == "" && region == "" {
+		cfg, err := newConfigBuilder(o.log).WithTLSSettings(insecureSkipTLSVerify, caCert).Build()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		client, err := newS3Client(cfg, s3URL, s3ForcePathStyle)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		region, err = manager.GetBucketRegion(context.Background(), client, bucket)
+		if err != nil {
+			o.log.Errorf("Failed to determine bucket's region bucket: %s, error: %v", bucket, err)
+			return err
+		}
+		if region == "" {
+			return fmt.Errorf("unable to determine bucket's region, bucket: %s", bucket)
+		}
+	}
+
+	cfg, err := newConfigBuilder(o.log).WithRegion(region).
+		WithProfile(credentialProfile).
+		WithCredentialsFile(credentialsFile).
+		WithTLSSettings(insecureSkipTLSVerify, caCert).Build()
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -63,19 +63,18 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 	region := config[regionKey]
 	credentialProfile := config[credentialProfileKey]
 	credentialsFile := config[credentialsFileKey]
-	//	enableSharedConfig := config[enableSharedConfigKey]
 
 	if region == "" {
 		return errors.Errorf("missing %s in aws configuration", regionKey)
 	}
-
-	cfg, err := newAWSConfig(region, credentialProfile, credentialsFile, false, "")
+	cfg, err := newConfigBuilder(b.log).
+		WithRegion(region).
+		WithProfile(credentialProfile).
+		WithCredentialsFile(credentialsFile).Build()
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
 	b.ec2 = ec2.NewFromConfig(cfg)
-
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/vmware-tanzu/velero/issues/3449 Use a builder to create aws config which will respect the TLS related settings in BSL while getting the bucket.