### PR TITLE
configuration for checksum algorithm for PutObject to S3

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -113,7 +113,15 @@ spec:
 
     # Tags that need to be placed on AWS S3 objects. 
     # For example "Key1=Value1&Key2=Value2"
+    #
     # Optional (defaults to empty "")
     tagging: ""
 
+    # The checksum algorithm to use for uploading objects to S3.
+    # The Supported values are  "CRC32",  "CRC32C", "SHA1", "SHA256".
+    # If the value is set as empty string "", no checksum will be calculated and attached to 
+    # the request headers.
+    #
+    # Optional (defaults to "CRC32")
+    checksumAlgorithm: "CRC32"
 ```

--- a/velero-plugin-for-aws/object_store_test.go
+++ b/velero-plugin-for-aws/object_store_test.go
@@ -112,3 +112,43 @@ func TestObjectExists(t *testing.T) {
 		})
 	}
 }
+
+func TestValidChecksumAlg(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "md5 is invalid",
+			input:    "MD5",
+			expected: false,
+		},
+		{
+			name:     "sha256 is invalid",
+			input:    "sha256",
+			expected: false,
+		},
+		{
+			name:     "SHA256 is valid",
+			input:    "SHA256",
+			expected: true,
+		},
+		{
+			name:     "empty is valid",
+			input:    "",
+			expected: true,
+		},
+		{
+			name:     "blank string with space is invalid",
+			input:    "  ",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, validChecksumAlg(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
CRC32 is the default algorith due to the low cost.

Cherrypicking the change from `main` branch so it's also configurable for plugin v1.9.x

fixes https://github.com/vmware-tanzu/velero/issues/7534