### PR TITLE
Set hinting region to use for GetBucketRegion()

### DIFF
--- a/changelogs/unreleased/210-kaovilai
+++ b/changelogs/unreleased/210-kaovilai
@@ -1,0 +1,1 @@
+Fix region discovery after aws-sdk-go-v2

--- a/velero-plugin-for-aws/config.go
+++ b/velero-plugin-for-aws/config.go
@@ -31,11 +31,6 @@ func (cb *configBuilder) WithRegion(region string) *configBuilder {
 	return cb
 }
 
-func (cb *configBuilder) WithAnonymousCredentials() *configBuilder {
-	cb.opts = append(cb.opts, config.WithCredentialsProvider(aws.AnonymousCredentials{}))
-	return cb
-}
-
 func (cb *configBuilder) WithProfile(profile string) *configBuilder {
 	cb.opts = append(cb.opts, config.WithSharedConfigProfile(profile))
 	return cb

--- a/velero-plugin-for-aws/config.go
+++ b/velero-plugin-for-aws/config.go
@@ -31,6 +31,11 @@ func (cb *configBuilder) WithRegion(region string) *configBuilder {
 	return cb
 }
 
+func (cb *configBuilder) WithAnonymousCredentials() *configBuilder {
+	cb.opts = append(cb.opts, config.WithCredentialsProvider(aws.AnonymousCredentials{}))
+	return cb
+}
+
 func (cb *configBuilder) WithProfile(profile string) *configBuilder {
 	cb.opts = append(cb.opts, config.WithSharedConfigProfile(profile))
 	return cb


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu/velero/issues/8022

Adds back region hinting removed in https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/177/files#diff-7ba4f8953b70f82b66f6ba15ea753c9bb847d2e01173baaef65574f60e57d86cL40-L41

Per following
https://github.com/aws/aws-sdk-go-v2/blob/4599f78694cabb6853addabc6f92cb197fdb5647/feature/s3/manager/bucket_region.go#L45-L47
AWS will make a request to `bucketname.s3.<regionHint>.amazonaws.com/`
Where region hint is obtained via config which in local dev machine could be loaded from `~/.aws/credentials` so unit tests if any won't fail but in a container/k8s environment where cred file is not available it may not work.

Related to fixes at https://github.com/openshift/oadp-operator/pull/1470
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

test image:
```
ghcr.io/kaovilai/velero-plugin-for-aws:bucket-region-hinting-anonymous-creds
```
<details><summary>Test image builds</summary>
<p>

```
❯ alias ghcr_tag 
ghcr_tag='echo ghcr.io/kaovilai/$(basename $PWD):$(git branch --show-current)'

~/git/velero-plugin-for-aws bucket-region-hinting-anonymous-creds
❯ IMAGE_TAGS=$(ghcr_tag) make container && docker push $(ghcr_tag) 

❯ ghcr_tag 
ghcr.io/kaovilai/velero-plugin-for-aws:bucket-region-hinting-anonymous-creds

❯ docker image inspect $(ghcr_tag) | grep Arch
        "Architecture": "amd64",
```

</p>
</details> 