### PR TITLE
Fix: Requests specifying Server Side Encryption with Customer provided keys must provide the client calculated MD5 of the secret key

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -13,18 +13,18 @@ spec:
   #
   # Required.
   provider: velero.io/aws
-  
+
   objectStorage:
     # The bucket in which to store backups.
     #
     # Required.
     bucket: my-bucket
-    
+
     # The prefix within the bucket under which to store backups.
     #
     # Optional.
     prefix: my-prefix
-  
+
   # The credentials intended to be used with this location.
   # optional (if not set, default credentials secret is used)
   credential:
@@ -45,13 +45,13 @@ spec:
     # Optional (defaults to "false").
     s3ForcePathStyle: "true"
 
-    # You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from 
+    # You can specify the AWS S3 URL here for explicitness, but Velero can already generate it from
     # "region" and "bucket". This field is primarily for local storage services like MinIO.
     #
     # Optional.
     s3Url: "http://minio:9000"
-    
-    # If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This 
+
+    # If specified, use this instead of "s3Url" when generating download URLs (e.g., for logs). This
     # field is primarily for local storage services like MinIO.
     #
     # Optional.
@@ -65,41 +65,43 @@ spec:
     serverSideEncryption: AES256
 
     # Specify an AWS KMS key ID (formatted per the example) or alias (formatted as "alias/<KMS-key-alias-name>"), or its full ARN
-    # to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly 
-    # granting key usage rights. 
+    # to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly
+    # granting key usage rights.
     #
     # Cannot be used in conjunction with customerKeyEncryptionFile.
     #
     # Optional.
     kmsKeyId: "502b409c-4da1-419f-a16e-eif453b3i49f"
-    
+
     # Specify the file that contains the SSE-C customer key to enable customer key encryption of the backups
     # stored in S3. The referenced file should contain a 32-byte string.
-    #  
+    #
     # The customerKeyEncryptionFile points to a mounted secret within the velero container.
-    # Add the below values to the velero cloud-credentials secret:
-    # customer-key: <your_b64_encoded_32byte_string>
+    # Generate a 32-byte key encoded in base64:
+    # openssl rand -base64 32 | tr -d '\n'
+    # Add the generated value to the velero cloud-credentials secret:
+    # customer-key: <generated-key>
     # The default value below points to the already mounted secret.
-    # 
+    #
     # Cannot be used in conjunction with kmsKeyId.
     #
     # Optional (defaults to "", which means SSE-C is disabled).
     customerKeyEncryptionFile: "/credentials/customer-key"
 
-    # Version of the signature algorithm used to create signed URLs that are used by velero CLI to 
-    # download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 
+    # Version of the signature algorithm used to create signed URLs that are used by velero CLI to
+    # download backups or fetch logs. Possible versions are "1" and "4". Usually the default version
     # 4 is correct, but some S3-compatible providers like Quobyte only support version 1.
     #
     # Optional (defaults to "4").
     signatureVersion: "1"
 
     # AWS profile within the credentials file to use for the backup storage location.
-    # 
+    #
     # Optional (defaults to "default").
     profile: "default"
 
-    # Set this to "true" if you do not want to verify the TLS certificate when connecting to the 
-    # object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle 
+    # Set this to "true" if you do not want to verify the TLS certificate when connecting to the
+    # object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle
     # attacks and is not recommended for production.
     #
     # Optional (defaults to "false").
@@ -111,7 +113,7 @@ spec:
     # Optional (defaults to "false").
     enableSharedConfig: "true"
 
-    # Tags that need to be placed on AWS S3 objects. 
+    # Tags that need to be placed on AWS S3 objects.
     # For example "Key1=Value1&Key2=Value2"
     #
     # Optional (defaults to empty "")
@@ -119,7 +121,7 @@ spec:
 
     # The checksum algorithm to use for uploading objects to S3.
     # The Supported values are  "CRC32",  "CRC32C", "SHA1", "SHA256".
-    # If the value is set as empty string "", no checksum will be calculated and attached to 
+    # If the value is set as empty string "", no checksum will be calculated and attached to
     # the request headers.
     #
     # Optional (defaults to "CRC32")

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,9 @@ require (
 	k8s.io/apimachinery v0.29.0
 )
 
+//TODO: Remove this replace before merging
+replace github.com/vmware-tanzu/velero v0.0.0-20240424061649-159a49f0b2b9 => github.com/esomore/velero v0.0.0-20240718180911-9053c280c77e
+
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.14 // indirect
@@ -66,11 +69,11 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.19.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
-	golang.org/x/term v0.19.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/term v0.21.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/grpc v1.63.2 // indirect

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -406,7 +406,7 @@ func (o *ObjectStore) DeleteObject(bucket, key string) error {
 	return errors.Wrapf(err, "error deleting object %s", key)
 }
 
-func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, http.Header, error) {
+func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, map[string][]string, error) {
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -406,10 +406,19 @@ func (o *ObjectStore) DeleteObject(bucket, key string) error {
 }
 
 func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
-	req, err := o.preSignS3.PresignGetObject(context.Background(), &s3.GetObjectInput{
+
+	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-	}, func(opts *s3.PresignOptions) {
+	}
+
+	if o.sseCustomerKey != "" {
+		input.SSECustomerAlgorithm = aws.String("AES256")
+		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
+	}
+
+	req, err := o.preSignS3.PresignGetObject(context.Background(), input, func(opts *s3.PresignOptions) {
 		opts.Expires = ttl
 	})
 

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"sort"
 	"strconv"
@@ -405,7 +406,7 @@ func (o *ObjectStore) DeleteObject(bucket, key string) error {
 	return errors.Wrapf(err, "error deleting object %s", key)
 }
 
-func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
+func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, http.Header, error) {
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
@@ -423,7 +424,7 @@ func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (st
 	})
 
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", http.Header{}, errors.WithStack(err)
 	}
-	return req.URL, nil
+	return req.URL, req.SignedHeader, nil
 }


### PR DESCRIPTION
This pull request fixes the object store plugin by adding MD5 checksum and using base64 encoding for the SSE customer key.

**Test Plan**
TLDR: The backup and restore are working
I am still trying to figure out about the CreateSignedURL function. This is why the error "The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object."  
My suspicion we are not adding the headers to the download request back in the velero backend and trying to address it here: https://github.com/vmware-tanzu/velero/pull/8025

```make test
docker build --platform linux/amd64 -t itamarperez/velero-plugin-for-aws:amd64v5 .
docker push docker.io/itamarperez/velero-plugin-for-aws:amd64v5
```

update velero helm chart:
```
initContainers:
  - name: velero-plugin-for-aws
    image: docker.io/itamarperez/velero-plugin-for-aws:amd64
    imagePullPolicy: IfNotPresent
    volumeMounts:
      - mountPath: /target
        name: plugins
```

ensure backup storage location config:
```
apiVersion: velero.io/v1
kind: BackupStorageLocation
metadata:
  name: aws
  namespace: velero
status:
  lastSyncedTime: '2024-07-17T01:54:38Z'
  lastValidationTime: '2024-07-17T01:54:48Z'
  phase: Available
spec:
  config:
    checksumAlgorithm: SHA256
    customerKeyEncryptionFile: /credentials/customer-key
    enableSharedConfig: 'false'
    insecureSkipTLSVerify: 'false'
    kmsKeyId: ''
    profile: default
    publicUrl: ''
    region: us-east-1
    s3ForcePathStyle: 'false'
    serverSideEncryption: AES256
    signatureVersion: '4'
    tagging: ''
  credential:
    key: cloud
    name: aws-cloud-credentials
  default: true
  objectStorage:
    bucket: velero
    prefix: ''
  provider: velero.io/aws
```

create a new backup:
```
velero backup create cosmicrocks-aws --include-namespaces cosmicrocks --storage-location aws
```

```
velero backup describe cosmicrocks-aws
Name:         cosmicrocks-aws
Namespace:    velero
Labels:       velero.io/storage-location=aws
Annotations:  velero.io/resource-timeout=10m0s
              velero.io/source-cluster-k8s-gitversion=v1.30.0
              velero.io/source-cluster-k8s-major-version=1
              velero.io/source-cluster-k8s-minor-version=30

Phase:  Completed


Namespaces:
  Included:  cosmicrocks
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        <none>
  Cluster-scoped:  auto

Label selector:  <none>

Or label selector:  <none>

Storage Location:  aws

Velero-Native Snapshot PVs:  auto
Snapshot Move Data:          true
Data Mover:                  velero

TTL:  720h0m0s

CSISnapshotTimeout:    10m0s
ItemOperationTimeout:  4h0m0s

Hooks:  <none>

Backup Format Version:  1.1.0

Started:    2024-07-16 18:32:56 -0700 PDT
Completed:  2024-07-16 18:32:59 -0700 PDT

Expiration:  2024-08-15 18:32:56 -0700 PDT

Total items to be backed up:  13
Items backed up:              13

Backup Volumes:
<error getting backup volume info: request failed: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidRequest</Code><Message>The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.</Message>
...

HooksAttempted:  0
HooksFailed:     0
```

```
velero restore create --from-backup cosmicrocks-aws
Restore request "cosmicrocks-aws-20240716183406" submitted successfully.
Run `velero restore describe cosmicrocks-aws-20240716183406` or `velero restore logs cosmicrocks-aws-20240716183406` for more details.
❯ velero restore describe cosmicrocks-aws-20240716183406
Name:         cosmicrocks-aws-20240716183406
Namespace:    velero
Labels:       <none>
Annotations:  <none>

Phase:                       Completed
Total items to be restored:  12
Items restored:              12
...
```