### PR TITLE
fix(docs): Add required S3 PutObjectTagging permission to IAM policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For more information, see [the AWS documentation on IAM users][10].
                     "s3:GetObject",
                     "s3:DeleteObject",
                     "s3:PutObject",
+                    "s3:PutObjectTagging",
                     "s3:AbortMultipartUpload",
                     "s3:ListMultipartUploadParts"
                 ],
@@ -225,6 +226,7 @@ It can be set up for Velero by creating a role that will have required permissio
                     "s3:GetObject",
                     "s3:DeleteObject",
                     "s3:PutObject",
+                    "s3:PutObjectTagging",
                     "s3:AbortMultipartUpload",
                     "s3:ListMultipartUploadParts"
                 ],

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ For more information, see [the AWS documentation on IAM users][10].
 
     If you'll be using Velero to backup multiple clusters with multiple S3 buckets, it may be desirable to create a unique username per cluster rather than the default `velero`.
 
-2. Attach policies to give `velero` the necessary permissions:
+2. Attach policies to give `velero` the necessary permissions (note that `s3:PutObjectTagging` is only needed 
+   if you make use of the `config.tagging` field in the `BackupStorageLocation` spec):
 
     ```
     cat > velero-policy.json <<EOF
@@ -200,7 +201,8 @@ It can be set up for Velero by creating a role that will have required permissio
     aws iam create-role --role-name velero --assume-role-policy-document file://./velero-trust-policy.json
     ```
 
-3. Attach policies to give `velero` the necessary permissions:
+3. Attach policies to give `velero` the necessary permissions (note that `s3:PutObjectTagging` is only needed 
+   if you make use of the `config.tagging` field in the `BackupStorageLocation` spec):
 
     ```
     BUCKET=<YOUR_BUCKET>

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -112,8 +112,7 @@ spec:
     enableSharedConfig: "true"
 
     # Tags that need to be placed on AWS S3 objects. 
-    # For example, "Key1=Value1&Key2=Value2".
-    # This requires the IAM policy to have the "s3:PutObjectTagging" permission on the S3 bucket.
+    # For example "Key1=Value1&Key2=Value2"
     #
     # Optional (defaults to empty "")
     tagging: ""

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -112,7 +112,8 @@ spec:
     enableSharedConfig: "true"
 
     # Tags that need to be placed on AWS S3 objects. 
-    # For example "Key1=Value1&Key2=Value2"
+    # For example, "Key1=Value1&Key2=Value2".
+    # This requires the IAM policy to have the "s3:PutObjectTagging" permission on the S3 bucket.
     #
     # Optional (defaults to empty "")
     tagging: ""

--- a/changelogs/unreleased/218-chrisRedwine
+++ b/changelogs/unreleased/218-chrisRedwine
@@ -1,0 +1,1 @@
+Add required S3 PutObjectTagging permission to IAM policy in README


### PR DESCRIPTION
Resolves https://github.com/vmware-tanzu/velero/issues/8062

Also, see this [issue](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/518) and this [PR](https://github.com/terraform-aws-modules/terraform-aws-iam/pull/517) for more details.