### PR TITLE
Add known compat issues with Non-AWS S3 compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Below is a listing of plugin versions and respective Velero versions that are co
 | v1.7.x         | v1.11.x        |
 | v1.6.x         | v1.10.x        |
 
+## Non-AWS S3 compatible provider known issues with plugin v1.10.x (aws-sdk-go-v2):
+| Cloud Provider      |Notes|Velero Issue|Cloud Provider Issue|
+|-|-|-|-|
+|Google Cloud Storage|[Should use GCP plugin instead](https://github.com/vmware-tanzu/velero-plugin-for-gcp)||https://issuetracker.google.com/issues/256641357|
+|Net App||https://github.com/vmware-tanzu/velero/issues/7828||
+|Oracle||https://github.com/vmware-tanzu/velero/issues/8013||
+|IBM COS|checksumAlgorithm="" should work if [replication is not enabled](https://github.com/vmware-tanzu/velero/issues/7543#issuecomment-2225803682)|https://github.com/vmware-tanzu/velero/issues/7543||
+|Hitachi Content Platform (HCP)||||
+
 ## Filing issues
 
 If you would like to file a GitHub issue for the plugin, please open the issue on the [core Velero repo][103]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Below is a listing of plugin versions and respective Velero versions that are co
 | Cloud Provider      |Notes|Velero Issue|Cloud Provider Issue|
 |-|-|-|-|
 |Google Cloud Storage|[Should use GCP plugin instead](https://github.com/vmware-tanzu/velero-plugin-for-gcp)||https://issuetracker.google.com/issues/256641357|
-|Net App||https://github.com/vmware-tanzu/velero/issues/7828||
+|Net App|`operation error S3: PutObject, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: The s3 command you requested is not implemented.`|https://github.com/vmware-tanzu/velero/issues/7828 https://github.com/vmware-tanzu/velero/issues/8152||
 |Oracle||https://github.com/vmware-tanzu/velero/issues/8013||
 |IBM COS|checksumAlgorithm="" should work if [replication is not enabled](https://github.com/vmware-tanzu/velero/issues/7543#issuecomment-2225803682)|https://github.com/vmware-tanzu/velero/issues/7543||
 |Hitachi Content Platform (HCP)||||

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Below is a listing of plugin versions and respective Velero versions that are co
 |Oracle||https://github.com/vmware-tanzu/velero/issues/8013||
 |IBM COS|checksumAlgorithm="" should work if [replication is not enabled](https://github.com/vmware-tanzu/velero/issues/7543#issuecomment-2225803682)|https://github.com/vmware-tanzu/velero/issues/7543||
 |Hitachi Content Platform (HCP)||||
-|OpenStack||https://github.com/vmware-tanzu/velero/issues/8264||
+|Cloudian||https://github.com/vmware-tanzu/velero/issues/8264||
 ## Filing issues
 
 If you would like to file a GitHub issue for the plugin, please open the issue on the [core Velero repo][103]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Below is a listing of plugin versions and respective Velero versions that are co
 |Oracle||https://github.com/vmware-tanzu/velero/issues/8013||
 |IBM COS|checksumAlgorithm="" should work if [replication is not enabled](https://github.com/vmware-tanzu/velero/issues/7543#issuecomment-2225803682)|https://github.com/vmware-tanzu/velero/issues/7543||
 |Hitachi Content Platform (HCP)||||
-
+|OpenStack||https://github.com/vmware-tanzu/velero/issues/8264||
 ## Filing issues
 
 If you would like to file a GitHub issue for the plugin, please open the issue on the [core Velero repo][103]


### PR DESCRIPTION
Longer term we probably want to add a plugin that use a more relaxed sdk that tends to add more compatibility rather than remove them like https://github.com/minio/minio-go/blob/99336902dd57f3760e272caf6550e6791eabe0af/pkg/signer/request-signature-v4.go#L59-L63