### PR TITLE
Prepare for v1.11 rc.2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.22'
+        go-version: '1.22.8'
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.22'
+        go-version: '1.22.8'
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.22.8-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/changelogs/CHANGELOG-1.11.0.md
+++ b/changelogs/CHANGELOG-1.11.0.md
@@ -1,0 +1,9 @@
+## All changes
+
+- static checks (#208, @kaovilai)
+- Futureproof validChecksumAlg()  (#209, @kaovilai)
+- Set hinting region to use for GetBucketRegion() (#210, @kaovilai)
+- fix(docs): Add required S3 PutObjectTagging permission to IAM policy in README (#218, @chrisRedwine)
+- Add known compat issues with Non-AWS S3 compatible providers (#219, @kaovilai)
+- bump up the dependencies of velero (#220, @reasonerjt)
+- Update the version matrix in README.md (#221, @reasonerjt)

--- a/changelogs/unreleased/210-kaovilai
+++ b/changelogs/unreleased/210-kaovilai
@@ -1,1 +1,0 @@
-Fix region discovery after aws-sdk-go-v2

--- a/changelogs/unreleased/218-chrisRedwine
+++ b/changelogs/unreleased/218-chrisRedwine
@@ -1,1 +1,0 @@
-Add required S3 PutObjectTagging permission to IAM policy in README

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/vmware-tanzu/velero-plugin-for-aws
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.8
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1
@@ -15,7 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	github.com/vmware-tanzu/velero v0.0.0-20241009105421-ba0dbb91f941
+	github.com/vmware-tanzu/velero v1.15.0-rc.2
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 )

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/vmware-tanzu/velero v0.0.0-20241009105421-ba0dbb91f941 h1:QX1KPBw5mtS+CtQzRyDJpDZPY8WE9apgQ4YolEeoK7o=
-github.com/vmware-tanzu/velero v0.0.0-20241009105421-ba0dbb91f941/go.mod h1:1Jk51qruLY/LCG8RMy6nVLVctIlWqJ9KBNXWroHzJZg=
+github.com/vmware-tanzu/velero v1.15.0-rc.2 h1:D0PmRJFXpwuKQaXUfyHpo0w75A7jdCHnmWvvUuz/6B8=
+github.com/vmware-tanzu/velero v1.15.0-rc.2/go.mod h1:28VhzPJRBo91GBRkgs4Ird0fx2vCpepBWmhF+5Pn/WQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
Pin golang to v1.22.8, and dependency velero to v1.15.0-rc.2 Also update changelog