### PR TITLE
fixed wrong errorhandling for customerKey size check

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -242,7 +242,7 @@ func readCustomerKey(customerKeyEncryptionFile string) (string, error) {
 	fileHandle.Close()
 
 	if nBytes != 32 {
-		return "", errors.Wrapf(err, "contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
+		return "", fmt.Errorf("contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
 	}
 
 	key := string(keyBytes)


### PR DESCRIPTION
The current Errorhandling is wrong. As previous err=nil, then errors.Wrapf does not throw an error. So error is swallowed and it looks like backup was successful (while it wasn't).