### PR TITLE
gschei/fix ssec base64 md5

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -242,7 +242,7 @@ func readCustomerKey(customerKeyEncryptionFile string) (string, error) {
 	fileHandle.Close()
 
 	if nBytes != 32 {
-		return "", errors.Wrapf(err, "contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
+		return "", fmt.Errorf("contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
 	}
 
 	key := string(keyBytes)

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -74,6 +76,7 @@ type ObjectStore struct {
 	s3Uploader           *manager.Uploader
 	kmsKeyID             string
 	sseCustomerKey       string
+	sseCustomerKeyMd5    string
 	signatureVersion     string
 	serverSideEncryption string
 	tagging              string
@@ -186,7 +189,9 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return err
 		}
-		o.sseCustomerKey = customerKey
+		o.sseCustomerKey = base64.StdEncoding.EncodeToString([]byte(customerKey))
+		hash := md5.Sum([]byte(customerKey))
+		o.sseCustomerKeyMd5 = base64.StdEncoding.EncodeToString(hash[:])
 	}
 
 	if publicURL != "" {
@@ -267,6 +272,7 @@ func (o *ObjectStore) PutObject(bucket, key string, body io.Reader) error {
 	case o.sseCustomerKey != "":
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	// otherwise, use the SSE algorithm specified, if any
 	case o.serverSideEncryption != "":
 		input.ServerSideEncryption = types.ServerSideEncryption(o.serverSideEncryption)
@@ -298,6 +304,7 @@ func (o *ObjectStore) ObjectExists(bucket, key string) (bool, error) {
 	if o.sseCustomerKey != "" {
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	}
 
 	log.Debug("Checking if object exists")
@@ -329,6 +336,7 @@ func (o *ObjectStore) GetObject(bucket, key string) (io.ReadCloser, error) {
 	if o.sseCustomerKey != "" {
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	}
 
 	output, err := o.s3.GetObject(context.Background(), input)


### PR DESCRIPTION
This PR is based on https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/224 and replaces PR https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/217 (which has some code duplication and is not complete).

It fixes these issues:
- the SSEC-CustomerKey is stored in the Velero Container as plain 32 byte key and must be base64 encoded before sending it to AWS.
- as shown in PR 217 MD5 hash is missing for head/get/put operations

I tested this change successfully  with an encrypted backup and restore with Velero and S3 Bucket.