### PR TITLE
fix: add Ceph S3 note about checksumAlgorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Below is a listing of plugin versions and respective Velero versions that are co
 |Hitachi Content Platform (HCP)||||
 |Cloudian||https://github.com/vmware-tanzu/velero/issues/8264||
 |Qumulo|not compatible with `x-id`, etc.|https://github.com/vmware-tanzu/velero/issues/8312||||
+|Ceph S3|checksumAlgorithm="" to avoid `api error XAmzContentSHA256Mismatch`||||
 ## Filing issues
 
 If you would like to file a GitHub issue for the plugin, please open the issue on the [core Velero repo][103]


### PR DESCRIPTION
As seen with many other S3-compatible storages, when using Ceph S3 you need to disable checksum header calculation.