### PR TITLE
Issue 8996: AWS plugin README lacks entries for velero 1.16 and AWS plugin 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Below is a listing of plugin versions and respective Velero versions that are co
 
 | Plugin Version | Velero Version |
 |----------------|----------------|
+| v1.12.x        | v1.16.x        |
 | v1.11.x        | v1.15.x        |
 | v1.10.x        | v1.14.x        |
 | v1.9.x         | v1.13.x        |

--- a/changelogs/unreleased/262-hu-keyu
+++ b/changelogs/unreleased/262-hu-keyu
@@ -1,0 +1,1 @@
+Update AWS plugin README


### PR DESCRIPTION
Update AWS plugin README

Fixes https://github.com/vmware-tanzu/velero/issues/8996