### PR TITLE
feat: add support age encryption

### DIFF
--- a/changelogs/unreleased/263-vring0
+++ b/changelogs/unreleased/263-vring0
@@ -1,0 +1,1 @@
+Add client-side encryption with age

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
+	filippo.io/age v1.2.1
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/config v1.26.3
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.11
@@ -80,6 +81,7 @@ require (
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
+filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
+filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 github.com/aws/aws-sdk-go-v2 v1.24.1 h1:xAojnj+ktS95YZlDf0zxWBkbFtymPeDP+rvUQIH3uAU=
 github.com/aws/aws-sdk-go-v2 v1.24.1/go.mod h1:LNh45Br1YAkEKaAqvmE1m8FUx6a5b/V0oAKV7of29b4=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 h1:OCs21ST2LrepDfD3lwlQiOqIGp6JiEUqG84GzTDoyJs=
@@ -219,6 +223,8 @@ go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -255,8 +261,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/velero-plugin-for-aws/age.go
+++ b/velero-plugin-for-aws/age.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"io"
+
+	"filippo.io/age"
+)
+
+type Age struct {
+	recipient string
+	key       string
+}
+
+func NewAge(recipient, key string) *Age {
+	return &Age{recipient: recipient, key: key}
+}
+
+func (a *Age) Encrypt(src io.Reader) (io.ReadCloser, error) {
+	recipient, err := age.ParseX25519Recipient(a.recipient)
+	if err != nil {
+		return nil, err
+	}
+
+	var outBuf bytes.Buffer
+
+	w, err := age.Encrypt(&outBuf, recipient)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
+	return io.NopCloser(bytes.NewReader(outBuf.Bytes())), nil
+}
+
+func (a *Age) Decrypt(src io.Reader) (io.ReadCloser, error) {
+	identity, err := age.ParseX25519Identity(a.key)
+	if err != nil {
+		return nil, err
+	}
+
+	plainR, err := age.Decrypt(src, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	var outBuf bytes.Buffer
+	if _, err := io.Copy(&outBuf, plainR); err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(outBuf.Bytes())), nil
+}

--- a/velero-plugin-for-aws/age_test.go
+++ b/velero-plugin-for-aws/age_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"filippo.io/age"
+)
+
+func TestAgeEncryptDecrypt_Stream(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	pub := id.Recipient().String()
+	priv := id.String()
+
+	ager := NewAge(pub, priv)
+
+	original := []byte("Test msg")
+
+	cipherRc, err := ager.Encrypt(bytes.NewReader(original))
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+	cipherData, err := io.ReadAll(cipherRc)
+	if err != nil {
+		t.Fatalf("reading ciphertext: %v", err)
+	}
+	cipherRc.Close()
+
+	if len(cipherData) == 0 {
+		t.Fatalf("cipherData empty")
+	}
+
+	plainRc, err := ager.Decrypt(bytes.NewReader(cipherData))
+	if err != nil {
+		t.Fatalf("Decrypt failed: %v", err)
+	}
+	recovered, err := io.ReadAll(plainRc)
+	if err != nil {
+		t.Fatalf("reading plaintext: %v", err)
+	}
+	plainRc.Close()
+
+	if !bytes.Equal(recovered, original) {
+		t.Errorf("Round-trip mismatch:\n got: %q\nwant: %q", recovered, original)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces optional client-side encryption using the [age](https://age-encryption.org/) tool to the Velero S3 object store plugin. Users can provide an `AGE_RECIPIENT` and `AGE_PRIVATE_KEY` via environment variables to transparently encrypt objects on `PutObject` and decrypt on `GetObject` without changes to existing workflows.

### Motivation

* Enhance data security by allowing client-side encryption before data leaves the Velero process.
* Complement existing server-side encryption (SSE) and customer-managed key (SSE-C) options with a modern, simple-to-use asymmetric encryption scheme.
* Support compliance requirements for end-to-end encryption in backup and restore.

#### Backward Compatibility

* If `AGE_RECIPIENT` or `AGE_PRIVATE_KEY` is not set, the plugin behaves exactly as before.
* Does not affect existing SSE or SSE-C configurations.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
