### PR TITLE
bump golang to 1.23.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.23.10-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vmware-tanzu/velero-plugin-for-aws
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.10
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1


### PR DESCRIPTION
Creating PR as per suggestion in comment -> https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/264#issuecomment-3021508928 by @blackpiglet 

This PR is not a hard requirement for now, merge it if required else we can close this later.