### PR TITLE
Fix SSE-C signed URLs

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -483,10 +483,18 @@ func (o *ObjectStore) DeleteObject(bucket, key string) error {
 }
 
 func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
-	req, err := o.preSignS3.PresignGetObject(context.Background(), &s3.GetObjectInput{
+	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-	}, func(opts *s3.PresignOptions) {
+	}
+
+	if o.sseCustomerKey != "" {
+		input.SSECustomerAlgorithm = aws.String("AES256")
+		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
+	}
+
+	req, err := o.preSignS3.PresignGetObject(context.Background(), input, func(opts *s3.PresignOptions) {
 		opts.Expires = ttl
 	})
 


### PR DESCRIPTION
## Related Issues

- Partial fix for https://github.com/vmware-tanzu/velero/issues/8668
- Supersedes https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/274

## Problem

When SSE-C encryption is configured (`customerKeyEncryptionFile` or `customerKeyEncryptionSecret`), the `CreateSignedURL` method does not include SSE-C headers in the presigned URL request. This causes S3-compatible backends to reject read operations with:

```
Requests specifying Server Side Encryption with Customer provided keys must provide a valid encryption algorithm.
```

## Testing

Tested against Hetzner Object Storage (Ceph) with SSE-C enabled. After this fix, the error changes from `InvalidArgument` (missing algorithm) to `SignatureDoesNotMatch`, confirming the headers are now correctly included in the signature.

The `BackupStorageLocation` used for testing:

```yaml
- name: default
  provider: aws
  default: true
  bucket: redacted
  config:
    region: fsn1
    s3ForcePathStyle: true
    s3Url: https://fsn1.your-objectstorage.com
    customerKeyEncryptionSecret: velero-sse-key/customer-key
```

## Remaining Issues

This PR fixes the plugin side only. A complete fix requires additional work in the Velero CLI, which currently performs plain HTTP GET requests to presigned URLs without sending the required SSE-C headers. This is tracked in https://github.com/vmware-tanzu/velero/issues/8668. I think the necessary changes would need to be done in https://github.com/vmware-tanzu/velero/blob/main/pkg/cmd/util/downloadrequest/downloadrequest.go.