### PR TITLE
fix: allow valid S3 object tag values

### DIFF
--- a/changelogs/unreleased/294-immanuwell
+++ b/changelogs/unreleased/294-immanuwell
@@ -1,0 +1,1 @@
+Fix S3 object tag validation to allow single tags and 256-character tag values.

--- a/velero-plugin-for-aws/helpers.go
+++ b/velero-plugin-for-aws/helpers.go
@@ -38,9 +38,6 @@ func IsValidS3URLScheme(s3URL string) bool {
 
 func CheckTags(tagging string) error {
 	tags := strings.Split(tagging, "&")
-	if len(tags) == 1 {
-		return errors.New("Tags are not seperated with an &")
-	}
 	for c, j := range tags {
 		if c > 9 {
 			return errors.New("Aws S3 allows only ten tags per object")
@@ -52,7 +49,7 @@ func CheckTags(tagging string) error {
 			if len([]rune(tg[0])) > 128 {
 				return errors.New("An S3 tag key can not be more than 128 Unicode characters in length")
 			} else {
-				if len([]rune(tg[1])) > 248 {
+				if len([]rune(tg[1])) > 256 {
 					return errors.New("An S3 tag values can not be more 256 Unicode characters in length")
 				}
 			}

--- a/velero-plugin-for-aws/helpers_test.go
+++ b/velero-plugin-for-aws/helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,10 @@ func TestS3Tags(t *testing.T) {
 	assert.Error(t, CheckTags("96FrFmTtJcBkEYEVtS3Bxrv2E37KG9m3M9CJqbtVCw7gy4UBEvpBC4h6xdV7FUBag7XeZhccvQuY8AgERdeWafBZRR7NRb8BnA6CkcqDHPpPPFpwLzXenjxZmeRK6J9hty=Value1&Key2=Value2&Key3=Value3"))
 	assert.Error(t, CheckTags("Key1=Value1&Key2=tka2MYGaFegMVkdm5nC58D46dyXCDbKcXnCZNrCHyS6s8TtMacs9HFXpGCNr2PVntCHArkKbgyYntVhBn2AAJXdKkvA9jdRrc4vCsYzCSZ4ZhCR7PBaKgMMdTtz93jRZNNFJcAqzrybDqCEmtKfFj3MdxLSvjej9tqP8bUt66449ZCbPuk8b7ASrYkPf6fQVYXM9rbmtyzWbhxtYdZs7nUaE4pQqtEfggqSEGbNaNWSf6x6vjUVJ2fAsZNfwKMxUwe"))
 	assert.Error(t, CheckTags("Key1=Value1&Key2=Value2&Key3-Value3&Key4=Value4&Key5=Value5&Key6=Value6&Key7=Value7&Key8=Value8&Key9=Value9&key10=Value10&Key11=Value11"))
+	assert.Nil(t, CheckTags("Key1=Value1"))
 	assert.Nil(t, CheckTags("Key1=Value1&Key2=Value2"))
+	assert.Nil(t, CheckTags("Key1="+strings.Repeat("a", 256)))
+	assert.Nil(t, CheckTags("Key1=Value1&Key2="+strings.Repeat("a", 256)))
+	assert.Error(t, CheckTags("Key1="+strings.Repeat("a", 257)))
 	assert.ErrorIs(t, CheckTags("Key1=Value1&Key2=Value2&Key3=Value3"), nil)
 }


### PR DESCRIPTION
Fixes a tiny S3 tag validation bug. small one, but real.

`CheckTags` rejected valid inputs:
- `Key1=Value1`
- `Key1=<256 chars>`

AWS allows up to 10 object tags, key <=128 chars, value <=256 chars. so these are legit, not a fake edge case.

Repro on old code:
```sh
go test ./velero-plugin-for-aws -run TestS3Tags -count=1
```

This adds coverage for one tag, 256-char values, and keeps 257-char values failing. Full `go test ./...` passes.

Related: #182