### PR TITLE
Only set PutObject Tagging when tags are configured

### DIFF
--- a/changelogs/unreleased/299-dillonbrowne
+++ b/changelogs/unreleased/299-dillonbrowne
@@ -1,0 +1,1 @@
+Fix Velero backups failing on Backblaze B2 (and other S3-compatible backends that reject an empty `x-amz-tagging` header) by only setting `PutObjectInput.Tagging` when the BSL `tagging` config is non-empty.

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -334,11 +334,28 @@ func readCustomerKeyFromSecret(secretRef string) (string, error) {
 }
 
 func (o *ObjectStore) PutObject(bucket, key string, body io.Reader) error {
+	input := o.buildPutObjectInput(bucket, key, body)
+
+	_, err := o.s3Uploader.Upload(context.Background(), input)
+
+	return errors.Wrapf(err, "error putting object %s", key)
+}
+
+// buildPutObjectInput constructs the PutObjectInput for an upload, applying
+// the ObjectStore's configured tagging, SSE, and checksum options. Each
+// optional field is only set when the corresponding config is non-empty —
+// some S3-compatible backends (notably Backblaze B2) reject requests that
+// carry these headers with empty values, e.g. an empty `x-amz-tagging`
+// header returns HTTP 400 "InvalidArgument: Unsupported header".
+func (o *ObjectStore) buildPutObjectInput(bucket, key string, body io.Reader) *s3.PutObjectInput {
 	input := &s3.PutObjectInput{
-		Bucket:  aws.String(bucket),
-		Key:     aws.String(key),
-		Body:    body,
-		Tagging: aws.String(o.tagging),
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   body,
+	}
+
+	if o.tagging != "" {
+		input.Tagging = aws.String(o.tagging)
 	}
 
 	switch {
@@ -361,9 +378,7 @@ func (o *ObjectStore) PutObject(bucket, key string, body io.Reader) error {
 		input.ChecksumAlgorithm = types.ChecksumAlgorithm(o.checksumAlg)
 	}
 
-	_, err := o.s3Uploader.Upload(context.Background(), input)
-
-	return errors.Wrapf(err, "error putting object %s", key)
+	return input
 }
 
 // ObjectExists checks if there is an object with the given key in the object storage bucket.

--- a/velero-plugin-for-aws/object_store_test.go
+++ b/velero-plugin-for-aws/object_store_test.go
@@ -393,3 +393,78 @@ func TestCreateSignedURL_NoSSECWhenNotConfigured(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://example.com/signed", url)
 }
+
+func TestBuildPutObjectInput(t *testing.T) {
+	tests := []struct {
+		name                       string
+		store                      *ObjectStore
+		expectTagging              *string
+		expectChecksumAlg          types.ChecksumAlgorithm
+		expectSSE                  types.ServerSideEncryption
+		expectSSEKMSKeyId          *string
+		expectSSECustomerAlgorithm *string
+		expectSSECustomerKey       *string
+		expectSSECustomerKeyMD5    *string
+	}{
+		{
+			// Regression guard: empty tagging config must NOT set
+			// PutObjectInput.Tagging. Passing aws.String("") here causes
+			// the SDK to serialize an empty `x-amz-tagging` header that
+			// Backblaze B2 (and other S3-compatible backends) reject with
+			// HTTP 400 InvalidArgument "Unsupported header".
+			name:          "empty config: no Tagging, no SSE, no checksum",
+			store:         &ObjectStore{log: newLogger()},
+			expectTagging: nil,
+		},
+		{
+			name:          "non-empty tagging config: Tagging is set",
+			store:         &ObjectStore{log: newLogger(), tagging: "Key1=Value1&Key2=Value2"},
+			expectTagging: aws.String("Key1=Value1&Key2=Value2"),
+		},
+		{
+			name:              "checksumAlgorithm CRC32: ChecksumAlgorithm is set",
+			store:             &ObjectStore{log: newLogger(), checksumAlg: "CRC32"},
+			expectChecksumAlg: types.ChecksumAlgorithmCrc32,
+		},
+		{
+			name:              "kmsKeyID set: SSE switches to aws:kms with the key ID",
+			store:             &ObjectStore{log: newLogger(), kmsKeyID: "arn:aws:kms:us-east-1:123:key/abc"},
+			expectSSE:         "aws:kms",
+			expectSSEKMSKeyId: aws.String("arn:aws:kms:us-east-1:123:key/abc"),
+		},
+		{
+			name: "sseCustomerKey set: SSE-C fields are populated",
+			store: &ObjectStore{
+				log:               newLogger(),
+				sseCustomerKey:    "raw-customer-key",
+				sseCustomerKeyMd5: "raw-customer-key-md5",
+			},
+			expectSSECustomerAlgorithm: aws.String("AES256"),
+			expectSSECustomerKey:       aws.String("raw-customer-key"),
+			expectSSECustomerKeyMD5:    aws.String("raw-customer-key-md5"),
+		},
+		{
+			name:      "serverSideEncryption set without kms/sse-c: ServerSideEncryption is set",
+			store:     &ObjectStore{log: newLogger(), serverSideEncryption: "AES256"},
+			expectSSE: types.ServerSideEncryptionAes256,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := tc.store.buildPutObjectInput("bucket", "key", nil)
+
+			require.NotNil(t, input)
+			assert.Equal(t, aws.String("bucket"), input.Bucket)
+			assert.Equal(t, aws.String("key"), input.Key)
+
+			assert.Equal(t, tc.expectTagging, input.Tagging, "Tagging mismatch")
+			assert.Equal(t, tc.expectChecksumAlg, input.ChecksumAlgorithm, "ChecksumAlgorithm mismatch")
+			assert.Equal(t, tc.expectSSE, input.ServerSideEncryption, "ServerSideEncryption mismatch")
+			assert.Equal(t, tc.expectSSEKMSKeyId, input.SSEKMSKeyId, "SSEKMSKeyId mismatch")
+			assert.Equal(t, tc.expectSSECustomerAlgorithm, input.SSECustomerAlgorithm, "SSECustomerAlgorithm mismatch")
+			assert.Equal(t, tc.expectSSECustomerKey, input.SSECustomerKey, "SSECustomerKey mismatch")
+			assert.Equal(t, tc.expectSSECustomerKeyMD5, input.SSECustomerKeyMD5, "SSECustomerKeyMD5 mismatch")
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Extracts `PutObject`'s input construction into a `buildPutObjectInput` helper and guards `Tagging` so it's only set when the user actually configured tags via the BSL `tagging` config.

```go
// Before (in PutObject)
input := &s3.PutObjectInput{
    Bucket:  aws.String(bucket),
    Key:     aws.String(key),
    Body:    body,
    Tagging: aws.String(o.tagging),
}
```

```go
// After
func (o *ObjectStore) buildPutObjectInput(bucket, key string, body io.Reader) *s3.PutObjectInput {
    input := &s3.PutObjectInput{
        Bucket: aws.String(bucket),
        Key:    aws.String(key),
        Body:   body,
    }
    if o.tagging != "" {
        input.Tagging = aws.String(o.tagging)
    }
    // ... existing kmsKeyID / sseCustomerKey / serverSideEncryption / checksumAlg logic ...
    return input
}
```

This matches the existing conditional pattern already used elsewhere in `PutObject` for `kmsKeyID`, `customerKeyEncryptionFile`, and `checksumAlgorithm`.

## Why

With the `aws-sdk-go-v2` version pulled in by the Go 1.25 bump for `v1.14.x`, passing `aws.String("")` for `Tagging` still serializes an empty `x-amz-tagging:` HTTP header on the PutObject request. **Backblaze B2** (and likely other S3-compatible backends that don't tolerate the empty header) rejects this with:

```
operation error S3: PutObject, https response error StatusCode: 400,
api error InvalidArgument: Unsupported header 'x-amz-tagging' received for this API call.
```

The failure is **silent and partial**: PVB data uploads through Kopia succeed (Kopia does its own writes); only the final `velero-backup.json` metadata write fails. The backup ends `Failed` with no `velero-backup.json` in the bucket, and the orphan PVB data is left in the Kopia repo. Schedules continue to fire and continue to fail every night until someone notices.

The older `aws-sdk-go-v2` in builds prior to `v1.14.0` omitted the header when the value was empty, which is why this never surfaced on the `v1.13.x` line.

## Repro

- Velero `v1.18.0` + plugin `v1.14.0` or `v1.14.1`
- BSL pointing at Backblaze B2 (`config.s3Url: https://s3.us-west-004.backblazeb2.com`, `config.s3ForcePathStyle: true`, no `tagging` configured)
- Any backup: PVBs complete, then `velero-backup.json` upload fails with the error above; backup goes to `Failed`.
- Downgrading the plugin to `v1.13.1` immediately restores working backups.
- `kubectl -n velero get backup <name> -o yaml | grep -A2 failureReason` shows the `x-amz-tagging` rejection.

## Why this fix is right

1. **Matches existing intent.** Every other optional field on `PutObjectInput` in this file (`SSEKMSKeyId`, `SSECustomerKey`, `ChecksumAlgorithm`) is set conditionally; `Tagging` was the lone exception.
2. **Zero behavior change for AWS S3 and any backend that accepts the empty header today** — they were already getting the same effective request (no tags applied) regardless of whether the header was sent empty or omitted.
3. **One-line behavior change, plus a small refactor to enable testing.** No new BSL config keys, no SDK version pins. The plugin stays decoupled from any specific `aws-sdk-go-v2` behavior change around empty headers.

## Regression test

`TestBuildPutObjectInput` is a new table-driven unit test that exercises the helper directly. It locks in:

- **empty config** produces `Tagging == nil`, `ChecksumAlgorithm == ""`, `ServerSideEncryption == ""`, all SSE-C / SSE-KMS pointers nil — i.e., the bug fix
- **`tagging: "Key1=Value1&Key2=Value2"`** sets `Tagging` verbatim
- **`checksumAlgorithm: "CRC32"`** sets `ChecksumAlgorithm`
- **`kmsKeyID: "..."`** switches `ServerSideEncryption` to `aws:kms` with the right key ID
- **`sseCustomerKey: "..."` + md5** populates all three SSE-C fields with `AES256`
- **`serverSideEncryption: "AES256"`** sets `ServerSideEncryption` directly when neither KMS nor SSE-C are configured

Anyone who later deletes the `if o.tagging != ""` guard (or accidentally regresses any of the other optional-field conditionals) fails the test, with a clear field-by-field diff in the failure message.

Why a helper instead of mocking `PutObject` directly: `PutObject` uploads via `o.s3Uploader.Upload(...)`, which is a concrete `*manager.Uploader` not behind an interface. Adding an interface to mock it would be a much larger refactor for equivalent coverage. The bug is entirely in input construction; testing the construction helper is the right granularity.

## Related

This is the second of two `v1.14.x`-era regressions for S3-compatible backends. The other — empty `checksumAlgorithm: ""` not actually suppressing trailing checksums because the SDK's `manager.Uploader` injects them via middleware — is reported in [velero-io/velero#9804](https://github.com/velero-io/velero/issues/9804). That one has a different fix path (setting `o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired` on the s3 client) and isn't addressed by this PR.

## Local CI mirror (Go 1.26.3)

```
$ gofmt -l .
(clean)

$ go vet ./...
(exit 0)

$ go test ./...
?   github.com/vmware-tanzu/velero-plugin-for-aws/hack/cp-plugin  [no test files]
ok  github.com/vmware-tanzu/velero-plugin-for-aws/velero-plugin-for-aws  0.467s
```

All existing unit tests pass plus the new `TestBuildPutObjectInput` (6 subtests, all PASS).

Ready for review once maintainers confirm the helper+test approach is the pattern they want.