### PR TITLE
updating compatibility matrix for latest plugin and velero versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Below is a listing of plugin versions and respective Velero versions that are co
 
 | Plugin Version | Velero Version |
 |----------------|----------------|
+| v1.14.x        | v1.18.x        |
 | v1.13.x        | v1.17.x        |
 | v1.12.x        | v1.16.x        |
 | v1.11.x        | v1.15.x        |


### PR DESCRIPTION
I noticed there's a new plugin and velero versions: 1.14.x on the plugin and 1.18.x on velero. Based on the existing matrix I am taking a guess that's what needs to be added to the compatibility matrix. Please evaluate and merge if so.

Thank you!