### PR TITLE
Add CODEOWNERS for automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+## maintainers are the overall code owners
+* @velero-io/Maintainer


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` (`* @velero-io/Maintainer`) so review requests happen automatically via GitHub's native code-owners feature — no third-party Action, no token, nothing to version-pin
- This repo has no path-based reviewer routing today, so a simple wildcard covers the existing need

See discussion: velero-io/velero#10018

> [!Note]
> Responses generated with Claude