### PR TITLE
docs: capitalize Kubernetes and fix phrasing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 This repository contains these plugins to support running Velero on AWS:
 
-- An object store plugin for persisting and retrieving backups on AWS S3. Content of backup is kubernetes resources and metadata files for CSI objects, progress of async operations.  
-  It is also used to store the result data of backups and restores include log files, warning/error files, etc.
+- An object store plugin for persisting and retrieving backups on AWS S3. Content of backup includes Kubernetes resources and metadata files for CSI objects, progress of async operations.  
+  It is also used to store the result data of backups and restores, including log files, warning/error files, etc.
 
 - A volume snapshotter plugin for creating snapshots from volumes (during a backup) and volumes from snapshots (during a restore) on AWS EBS.
   - Since v1.4.0 the snapshotter plugin can handle the volumes provisioned by CSI driver `ebs.csi.aws.com`


### PR DESCRIPTION
## Description
This PR fixes capitalization and grammar in `README.md`.

## Details
1. Capitalized proper noun `kubernetes` -> `Kubernetes`.
2. Fixed phrasing `restores include log files` -> `restores, including log files`.