### PR TITLE
Opt the transfer manager out of automatic multipart checksums

### DIFF
--- a/changelogs/unreleased/309-multipart-checksum
+++ b/changelogs/unreleased/309-multipart-checksum
@@ -1,0 +1,1 @@
+Also opt the S3 transfer manager out of automatic checksums, so multipart uploads work on backends that reject the aws-chunked trailer.

--- a/changelogs/unreleased/309-multipart-checksum
+++ b/changelogs/unreleased/309-multipart-checksum
@@ -1,1 +1,0 @@
-Also opt the S3 transfer manager out of automatic checksums, so multipart uploads work on backends that reject the aws-chunked trailer.

--- a/changelogs/unreleased/317-multipart-checksum
+++ b/changelogs/unreleased/317-multipart-checksum
@@ -1,0 +1,1 @@
+opt the S3 transfer manager out of automatic checksums, so multipart uploads work on backends that reject the aws-chunked trailer.

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -182,7 +182,11 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		return errors.WithStack(err)
 	}
 	o.s3 = client
-	o.s3Uploader = manager.NewUploader(client)
+	// The transfer manager keeps its own setting and does not inherit the client's.
+	// See https://github.com/velero-io/velero/issues/9804
+	o.s3Uploader = manager.NewUploader(client, func(u *manager.Uploader) {
+		u.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	})
 	o.kmsKeyID = kmsKeyID
 	o.serverSideEncryption = serverSideEncryption
 	o.tagging = tagging


### PR DESCRIPTION
### Problem

#308 set `RequestChecksumCalculation` on the S3 client, which fixed single-part `PutObject` on S3-compatible backends. It does not fix multipart.

`manager.Uploader` keeps its own copy of that setting and does not inherit it from the client, so every part still goes out as `aws-chunked` with a trailing CRC32:

```
PUT ...?partNumber=1&uploadId=...
     X-Amz-Content-Sha256 = STREAMING-UNSIGNED-PAYLOAD-TRAILER
     Content-Encoding     = aws-chunked
     X-Amz-Trailer        = x-amz-checksum-crc32
     X-Amz-Sdk-Checksum-Algorithm = CRC32
```

Backends that reject that framing return an error and the backup fails. Because the transfer manager only switches to multipart above its 5 MB part size, the small metadata objects people usually report succeed while **every non-trivial backup fails**, which makes this look intermittent.

Size is not the trigger, the framing is: 12 MB in a single part succeeds, the same 12 MB split into parts does not.

### Fix

Pass the same opt-out to the transfer manager. The field was added for exactly this in aws/aws-sdk-go-v2#3151 (issue aws/aws-sdk-go-v2#3007).

### Verification

Against Dell ECS, with the SDK versions this repo currently vendors (`service/s3 v1.101.0`, `feature/s3/manager v1.22.18`):

| config | `UploadPart` framing | result |
| --- | --- | --- |
| client flag only (#308) | `STREAMING-UNSIGNED-PAYLOAD-TRAILER` | 400 |
| client flag + this change | `UNSIGNED-PAYLOAD` | 200 |

With this change the parts are byte-identical to what plugin v1.13.x emitted before the SDK bump, which is the last version known to work on these backends.

### Not a behaviour change for checksum users

`WhenRequired` only suppresses *automatic* checksums. An explicitly requested algorithm is still applied and still trailered, verified:

| `checksumAlgorithm` | `UploadPart` | outcome |
| --- | --- | --- |
| unset | `UNSIGNED-PAYLOAD`, no trailer | 200 |
| `CRC32` | trailer sent, `alg=CRC32` | unchanged |

Since `checksumAlgorithm` defaults to CRC32 when the key is absent, users on AWS S3 and anyone who has not explicitly set `checksumAlgorithm: ""` are unaffected.

### Scope

This is the plugin's only upload path: one `manager.NewUploader` and one `Upload` call, both in `object_store.go`.

### Testing done

- `go build ./...` and `go vet` clean.
- The plugin image builds from the repo's own Dockerfile with the change applied.
- Wire-level verification against a real Dell ECS endpoint as above.
- Not yet exercised inside a running Velero server; the verification used the same SDK calls the plugin makes.

Refs velero-io/velero#9804, velero-io/velero#9951.
