### PR TITLE
[release-1.14] Add descriptive error message when SSE-C is denied on S3 buckets (cherry-pick #318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,28 @@ The secret must exist in the same namespace as Velero (determined by the `VELERO
 
 ### Important Notes about SSE-C
 
+- **New S3 buckets require SSE-C to be explicitly enabled.** As of April 2026, AWS disables SSE-C by default on all new S3 general purpose buckets. You must enable it on the bucket before use, otherwise S3 will return HTTP 403 (Access Denied) on all SSE-C operations. Enable SSE-C with the AWS CLI:
+
+  ```bash
+  aws s3api put-bucket-encryption \
+    --bucket $BUCKET \
+    --server-side-encryption-configuration '{
+      "Rules": [{
+        "ApplyServerSideEncryptionByDefault": {
+          "SSEAlgorithm": "AES256"
+        },
+        "BucketKeyEnabled": false,
+        "BlockedEncryptionTypes": {
+          "EncryptionType": ["NONE"]
+        }
+      }]
+    }'
+  ```
+
+  For more details, see the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html).
+
+  **If you do not need customer-managed keys, consider using SSE-KMS (`kmsKeyId`) instead.** SSE-KMS does not require this extra bucket configuration step and supports key rotation managed by AWS KMS.
+
 - The customer key must be exactly 32 bytes
 - You cannot use SSE-C in combination with `kmsKeyId`
 - You must specify either `customerKeyEncryptionFile` or `customerKeyEncryptionSecret`, not both

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -84,6 +84,11 @@ spec:
     # 
     # Cannot be used in conjunction with kmsKeyId or customerKeyEncryptionSecret.
     #
+    # NOTE: As of April 2026, AWS disables SSE-C by default on new S3 buckets.
+    # You must explicitly enable SSE-C on the bucket using the PutBucketEncryption
+    # API before using this option. See the README for details.
+    # Consider using kmsKeyId (SSE-KMS) instead, which does not require this step.
+    #
     # Optional (defaults to "", which means SSE-C is disabled).
     customerKeyEncryptionFile: "/credentials/customer-key"
     
@@ -99,6 +104,11 @@ spec:
     # - The key value must be exactly 32 bytes
     #
     # Cannot be used in conjunction with kmsKeyId or customerKeyEncryptionFile.
+    #
+    # NOTE: As of April 2026, AWS disables SSE-C by default on new S3 buckets.
+    # You must explicitly enable SSE-C on the bucket using the PutBucketEncryption
+    # API before using this option. See the README for details.
+    # Consider using kmsKeyId (SSE-KMS) instead, which does not require this step.
     #
     # Optional (defaults to "", which means SSE-C is disabled).
     customerKeyEncryptionSecret: ""

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -34,6 +34,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -333,12 +334,34 @@ func readCustomerKeyFromSecret(secretRef string) (string, error) {
 	return string(customerKeyData), nil
 }
 
+// wrapSSECError checks whether err is an AccessDenied response while SSE-C is
+// configured, and if so, wraps it with guidance about the April 2026 S3 policy
+// change that disables SSE-C by default on new buckets.
+func (o *ObjectStore) wrapSSECError(err error, operation string) error {
+	if err == nil || o.sseCustomerKey == "" {
+		return err
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDenied" {
+		return errors.Wrapf(err,
+			"%s failed: SSE-C encryption was denied by S3. "+
+				"As of April 2026, new S3 buckets disable SSE-C by default. "+
+				"Enable SSE-C on the bucket with the PutBucketEncryption API, or "+
+				"switch to SSE-KMS (kmsKeyId) which does not require this step",
+			operation,
+		)
+	}
+	return err
+}
+
 func (o *ObjectStore) PutObject(bucket, key string, body io.Reader) error {
 	input := o.buildPutObjectInput(bucket, key, body)
 
 	_, err := o.s3Uploader.Upload(context.Background(), input)
-
-	return errors.Wrapf(err, "error putting object %s", key)
+	if err != nil {
+		return o.wrapSSECError(errors.Wrapf(err, "error putting object %s", key), "PutObject")
+	}
+	return nil
 }
 
 // buildPutObjectInput constructs the PutObjectInput for an upload, applying
@@ -414,7 +437,7 @@ func (o *ObjectStore) ObjectExists(bucket, key string) (bool, error) {
 			).Debug("Object doesn't exist - got not found")
 			return false, nil
 		}
-		return false, errors.WithStack(err)
+		return false, o.wrapSSECError(errors.WithStack(err), "HeadObject")
 	}
 
 	log.Debug("Object exists")
@@ -435,7 +458,7 @@ func (o *ObjectStore) GetObject(bucket, key string) (io.ReadCloser, error) {
 
 	output, err := o.s3.GetObject(context.Background(), input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting object %s", key)
+		return nil, o.wrapSSECError(errors.Wrapf(err, "error getting object %s", key), "GetObject")
 	}
 
 	return output.Body, nil
@@ -514,7 +537,7 @@ func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (st
 	})
 
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", o.wrapSSECError(errors.WithStack(err), "CreateSignedURL")
 	}
 	return req.URL, nil
 }

--- a/velero-plugin-for-aws/object_store_test.go
+++ b/velero-plugin-for-aws/object_store_test.go
@@ -25,6 +25,7 @@ import (
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -467,4 +468,113 @@ func TestCreateSignedURL_NoSSECWhenNotConfigured(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://example.com/signed", url)
+}
+
+func TestWrapSSECError(t *testing.T) {
+	tests := []struct {
+		name           string
+		sseCustomerKey string
+		inputErr       error
+		expectContains string
+		expectWrapped  bool
+	}{
+		{
+			name:           "nil error returns nil",
+			sseCustomerKey: "some-key",
+			inputErr:       nil,
+		},
+		{
+			name:           "AccessDenied with SSE-C configured wraps with guidance",
+			sseCustomerKey: "some-key",
+			inputErr:       &smithy.GenericAPIError{Code: "AccessDenied", Message: "Access Denied"},
+			expectContains: "SSE-C encryption was denied by S3",
+			expectWrapped:  true,
+		},
+		{
+			name:           "AccessDenied without SSE-C configured returns original error",
+			sseCustomerKey: "",
+			inputErr:       &smithy.GenericAPIError{Code: "AccessDenied", Message: "Access Denied"},
+			expectContains: "Access Denied",
+			expectWrapped:  false,
+		},
+		{
+			name:           "non-AccessDenied error with SSE-C configured returns original error",
+			sseCustomerKey: "some-key",
+			inputErr:       &smithy.GenericAPIError{Code: "NoSuchBucket", Message: "bucket not found"},
+			expectContains: "bucket not found",
+			expectWrapped:  false,
+		},
+		{
+			name:           "non-API error with SSE-C configured returns original error",
+			sseCustomerKey: "some-key",
+			inputErr:       errors.New("connection refused"),
+			expectContains: "connection refused",
+			expectWrapped:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &ObjectStore{
+				log:            newLogger(),
+				sseCustomerKey: tc.sseCustomerKey,
+			}
+
+			result := o.wrapSSECError(tc.inputErr, "TestOp")
+
+			if tc.inputErr == nil {
+				assert.NoError(t, result)
+				return
+			}
+
+			require.Error(t, result)
+			assert.Contains(t, result.Error(), tc.expectContains)
+
+			if tc.expectWrapped {
+				assert.Contains(t, result.Error(), "PutBucketEncryption")
+				assert.Contains(t, result.Error(), "TestOp")
+			}
+		})
+	}
+}
+
+func TestObjectExists_SSECAccessDenied(t *testing.T) {
+	s := new(mockS3)
+	defer s.AssertExpectations(t)
+
+	o := &ObjectStore{
+		log:            newLogger(),
+		s3:             s,
+		sseCustomerKey: "some-key",
+	}
+
+	s.On("HeadObject", context.Background(), mock.Anything).Return(
+		&s3.HeadObjectOutput{},
+		&smithy.GenericAPIError{Code: "AccessDenied", Message: "Access Denied"},
+	)
+
+	_, err := o.ObjectExists("bucket", "key")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SSE-C encryption was denied by S3")
+	assert.Contains(t, err.Error(), "PutBucketEncryption")
+}
+
+func TestGetObject_SSECAccessDenied(t *testing.T) {
+	s := new(mockS3)
+	defer s.AssertExpectations(t)
+
+	o := &ObjectStore{
+		log:            newLogger(),
+		s3:             s,
+		sseCustomerKey: "some-key",
+	}
+
+	s.On("GetObject", context.Background(), mock.Anything).Return(
+		&s3.GetObjectOutput{},
+		&smithy.GenericAPIError{Code: "AccessDenied", Message: "Access Denied"},
+	)
+
+	_, err := o.GetObject("bucket", "key")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SSE-C encryption was denied by S3")
 }


### PR DESCRIPTION
Cherry-pick of #318 to `release-1.14`.

Original PR: https://github.com/velero-io/velero-plugin-for-aws/pull/318

Cherry-picked commit 3eb40b5 cleanly except for one conflict in `object_store_test.go` where this branch already carried its own (byte-identical) copy of `TestBuildPutObjectInput` from an earlier backport — resolved by keeping a single copy, no behavior change.

> [!Note]
> Responses generated with Claude
