### PR TITLE
[release-1.13] Add support for specifying KMS key for EBS volume restoration (cherry-pick #276)

### DIFF
--- a/changelogs/unreleased/276-tropnikovvl
+++ b/changelogs/unreleased/276-tropnikovvl
@@ -1,0 +1,1 @@
+Add support for specifying KMS key for EBS volume restoration from snapshots via `ebsKmsKeyId` parameter in VolumeSnapshotLocation configuration.

--- a/volumesnapshotlocation.md
+++ b/volumesnapshotlocation.md
@@ -29,7 +29,7 @@ spec:
     region: us-east-1
 
     # AWS profile within the credentials file to use for the volume snapshot location.
-    # 
+    #
     # Optional (defaults to "default").
     profile: "default"
 
@@ -38,4 +38,12 @@ spec:
     #
     # Optional (defaults to "false").
     enableSharedConfig: "true"
+
+    # The KMS key ID to use for encrypting EBS volumes restored from snapshots.
+    # If not specified, volumes will inherit encryption settings from the snapshot.
+    # Supports multiple formats: Key ID, Key alias (e.g., "alias/my-key"),
+    # Key ARN, or Alias ARN.
+    #
+    # Optional.
+    ebsKmsKeyId: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
 ```


### PR DESCRIPTION
Cherry-pick of #276 to `release-1.13`.

Original PR: https://github.com/velero-io/velero-plugin-for-aws/pull/276

Server-side feature (AWS EBS/EC2 API accepts an `ebsKmsKeyId` parameter for volume restoration) — unrelated to any SDK version, clean pick.

> [!Note]
> Responses generated with Claude
