### PR TITLE
[release-1.13] Fix SSE-C signed URLs (cherry-pick #280)

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -483,10 +483,18 @@ func (o *ObjectStore) DeleteObject(bucket, key string) error {
 }
 
 func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
-	req, err := o.preSignS3.PresignGetObject(context.Background(), &s3.GetObjectInput{
+	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-	}, func(opts *s3.PresignOptions) {
+	}
+
+	if o.sseCustomerKey != "" {
+		input.SSECustomerAlgorithm = aws.String("AES256")
+		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
+	}
+
+	req, err := o.preSignS3.PresignGetObject(context.Background(), input, func(opts *s3.PresignOptions) {
 		opts.Expires = ttl
 	})
 


### PR DESCRIPTION
Cherry-pick of #280 to `release-1.13`.

Original PR: https://github.com/velero-io/velero-plugin-for-aws/pull/280

Server-side requirement (S3 rejects presigned SSE-C requests missing the algorithm header) — unrelated to any SDK version, clean pick.

> [!Note]
> Responses generated with Claude
