### PR TITLE
Fix presigned URLs when the S3 URL carries a default port

### DIFF
--- a/changelogs/unreleased/327-thaildhe172591
+++ b/changelogs/unreleased/327-thaildhe172591
@@ -1,0 +1,1 @@
+Strip the scheme's default port from s3Url and publicUrl so presigned URLs carry the same host that was signed, fixing SignatureDoesNotMatch on S3-compatible backends.

--- a/velero-plugin-for-aws/config.go
+++ b/velero-plugin-for-aws/config.go
@@ -103,7 +103,7 @@ func newS3Client(cfg aws.Config, url string, forcePathStyle bool) (*s3.Client, e
 			return nil, errors.Errorf("Invalid s3 url %s, URL must be valid according to https://golang.org/pkg/net/url/#Parse and start with http:// or https://", url)
 		}
 		opts = append(opts, func(o *s3.Options) {
-			o.BaseEndpoint = aws.String(url)
+			o.BaseEndpoint = aws.String(stripDefaultPort(url))
 		})
 	}
 

--- a/velero-plugin-for-aws/helpers.go
+++ b/velero-plugin-for-aws/helpers.go
@@ -36,6 +36,36 @@ func IsValidS3URLScheme(s3URL string) bool {
 	return true
 }
 
+// stripDefaultPort removes the port from an S3 endpoint URL when it is the
+// default for the URL's scheme, and returns the URL unchanged otherwise.
+//
+// The SigV4 signer omits a scheme-default port from the host header it signs,
+// but leaves the port in the request URL. That is invisible for a request the
+// plugin sends itself, because the signer rewrites the outgoing Host header to
+// match. It is not invisible in a presigned URL: whoever fetches it derives the
+// Host from the URL, so the server hashes "host:443" against a signature
+// computed over "host". Amazon S3 normalizes the Host header before verifying
+// and hides the discrepancy, but S3-compatible backends generally do not and
+// answer SignatureDoesNotMatch.
+//
+// See https://github.com/velero-io/velero/issues/10114
+func stripDefaultPort(s3URL string) string {
+	u, err := url.Parse(s3URL)
+	if err != nil {
+		return s3URL
+	}
+
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		// Trimming the suffix rather than using u.Hostname() keeps the brackets
+		// around an IPv6 literal.
+		u.Host = strings.TrimSuffix(u.Host, ":"+port)
+		return u.String()
+	}
+
+	return s3URL
+}
+
 func CheckTags(tagging string) error {
 	tags := strings.Split(tagging, "&")
 	for c, j := range tags {

--- a/velero-plugin-for-aws/helpers_test.go
+++ b/velero-plugin-for-aws/helpers_test.go
@@ -30,6 +30,33 @@ func TestS3URL(t *testing.T) {
 	assert.False(t, IsValidS3URLScheme(""))
 }
 
+func TestStripDefaultPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		s3URL    string
+		expected string
+	}{
+		{name: "https default port", s3URL: "https://s3.example.com:443", expected: "https://s3.example.com"},
+		{name: "http default port", s3URL: "http://s3.example.com:80", expected: "http://s3.example.com"},
+		{name: "https default port with a path", s3URL: "https://s3.example.com:443/prefix", expected: "https://s3.example.com/prefix"},
+		{name: "https non-default port", s3URL: "https://s3.example.com:9000", expected: "https://s3.example.com:9000"},
+		{name: "http non-default port", s3URL: "http://s3.example.com:8080", expected: "http://s3.example.com:8080"},
+		{name: "https port that is the default of the other scheme", s3URL: "https://s3.example.com:80", expected: "https://s3.example.com:80"},
+		{name: "no port", s3URL: "https://s3.example.com", expected: "https://s3.example.com"},
+		{name: "uppercase scheme", s3URL: "HTTPS://s3.example.com:443", expected: "https://s3.example.com"},
+		{name: "IPv6 literal keeps its brackets", s3URL: "https://[2001:db8::1]:443", expected: "https://[2001:db8::1]"},
+		{name: "IPv6 literal with a non-default port", s3URL: "https://[2001:db8::1]:9000", expected: "https://[2001:db8::1]:9000"},
+		{name: "empty", s3URL: "", expected: ""},
+		{name: "unparseable url is left alone", s3URL: "https://s3.example.com:44 3", expected: "https://s3.example.com:44 3"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stripDefaultPort(tc.s3URL))
+		})
+	}
+}
+
 func TestS3Tags(t *testing.T) {
 	assert.Error(t, CheckTags("96FrFmTtJcBkEYEVtS3Bxrv2E37KG9m3M9CJqbtVCw7gy4UBEvpBC4h6xdV7FUBag7XeZhccvQuY8AgERdeWafBZRR7NRb8BnA6CkcqDHPpPPFpwLzXenjxZmeRK6J9hty=Value1&Key2=Value2&Key3=Value3"))
 	assert.Error(t, CheckTags("Key1=Value1&Key2=tka2MYGaFegMVkdm5nC58D46dyXCDbKcXnCZNrCHyS6s8TtMacs9HFXpGCNr2PVntCHArkKbgyYntVhBn2AAJXdKkvA9jdRrc4vCsYzCSZ4ZhCR7PBaKgMMdTtz93jRZNNFJcAqzrybDqCEmtKfFj3MdxLSvjej9tqP8bUt66449ZCbPuk8b7ASrYkPf6fQVYXM9rbmtyzWbhxtYdZs7nUaE4pQqtEfggqSEGbNaNWSf6x6vjUVJ2fAsZNfwKMxUwe"))

--- a/velero-plugin-for-aws/object_store_test.go
+++ b/velero-plugin-for-aws/object_store_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
@@ -393,6 +394,76 @@ func TestCreateSignedURL_NoSSECWhenNotConfigured(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://example.com/signed", url)
+}
+
+// A presigned URL is verified by whoever fetches it, and that party derives the
+// Host header from the URL itself. The SigV4 signer omits a scheme-default port
+// from the host it signs but leaves it in the URL, so an endpoint configured as
+// https://host:443 is signed over "host" and presented as "host:443". Amazon S3
+// normalizes the Host header before verifying and hides the discrepancy;
+// S3-compatible backends generally do not and answer SignatureDoesNotMatch.
+// See https://github.com/velero-io/velero/issues/10114
+func TestPresignedURLHostOmitsDefaultPort(t *testing.T) {
+	tests := []struct {
+		name           string
+		endpoint       string
+		forcePathStyle bool
+		expectedHost   string
+	}{
+		{
+			name:           "https without a port is unchanged",
+			endpoint:       "https://s3.example.com",
+			forcePathStyle: true,
+			expectedHost:   "s3.example.com",
+		},
+		{
+			name:           "https drops the default port",
+			endpoint:       "https://s3.example.com:443",
+			forcePathStyle: true,
+			expectedHost:   "s3.example.com",
+		},
+		{
+			name:           "http drops the default port",
+			endpoint:       "http://s3.example.com:80",
+			forcePathStyle: true,
+			expectedHost:   "s3.example.com",
+		},
+		{
+			name:           "a non-default port is kept",
+			endpoint:       "https://s3.example.com:9000",
+			forcePathStyle: true,
+			expectedHost:   "s3.example.com:9000",
+		},
+		{
+			name:         "virtual host style drops the default port",
+			endpoint:     "https://s3.example.com:443",
+			expectedHost: "test-bucket.s3.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := aws.Config{
+				Region: "us-east-1",
+				Credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+					return aws.Credentials{AccessKeyID: "access-key", SecretAccessKey: "secret-key"}, nil
+				}),
+			}
+
+			client, err := newS3Client(cfg, tc.endpoint, tc.forcePathStyle)
+			require.NoError(t, err)
+
+			req, err := s3.NewPresignClient(client).PresignGetObject(context.Background(), &s3.GetObjectInput{
+				Bucket: aws.String("test-bucket"),
+				Key:    aws.String("test-key"),
+			}, func(o *s3.PresignOptions) { o.Expires = time.Hour })
+			require.NoError(t, err)
+
+			signed, err := url.Parse(req.URL)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedHost, signed.Host)
+		})
+	}
 }
 
 func TestBuildPutObjectInput(t *testing.T) {


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

An endpoint configured as `https://host:443` is signed over `host` but presented as `host:443`. The SigV4 signer omits a scheme-default port from the host header it signs and leaves the port in the request URL. For a request the plugin sends itself that mismatch never surfaces, because the signer also rewrites the outgoing `Host` header to the value it signed. A presigned URL gets no such chance: whoever fetches it derives the `Host` from the URL, so the server hashes `host:443` against a signature computed over `host`.

Amazon S3 normalizes the `Host` header before verifying, which is why this stays hidden there. S3-compatible backends generally do not, and answer `SignatureDoesNotMatch`. The reporter's NetApp StorageGRID 11.9 is one; removing `:443` from `s3Url` was their workaround.

Worth noting for anyone reading the issue thread: `SanitizeHostForHeader` is doing its job. With the AWS SDK this plugin currently pins, `https://s3.example.com` and `https://s3.example.com:443` produce a byte-identical signature, and the canonical string reads `host:s3.example.com` in both. What differs is the URL that comes back out. The `host:<name>:443` the reporter saw is the `CanonicalRequest` the server echoed in its error, built from the `Host` it received.

The change strips the port from the endpoint when it is the default for the scheme, at the single point where the endpoint reaches the SDK, so `s3Url` and `publicUrl` are both covered. A non-default port is part of the signed host and is left alone.

Verified with `make ci` under Go 1.25.0, which is what `get-go-version` picks for `main`: `verify-modules` clean, 21 tests pass, none failing. The new presign test fails on `main` for the two default-port cases and passes with the change; the two control cases (no port, port 9000) pass either way. Coverage measured on the same machine and command goes from 46.3% to 48.0%.

The issue also raises `BaseEndpoint` precedence against `AWS_ENDPOINT_URL_S3` and the shared config file, the region-detection condition in `object_store.go`, and whether `IsValidS3URLScheme` should exist at all. I left those alone. They are design questions rather than the reported failure, and folding them in would make this harder to review. Happy to open separate issues if you want them tracked.

# Does your change fix a particular issue?

Fixes https://github.com/velero-io/velero/issues/10114

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

On the last box: no doc change looks warranted here. `backupstoragelocation.md` does not discuss ports, and after this change a default port in `s3Url` is simply harmless, so there is nothing a user needs to be told. Say the word if you would rather it were called out.
